### PR TITLE
TASK-58: Show in fullscreen apps toggle

### DIFF
--- a/.claude/skills/openwhisper-iteration-budget/SKILL.md
+++ b/.claude/skills/openwhisper-iteration-budget/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: openwhisper-iteration-budget
+description: Iteration discipline rule — at most TWO code attempts at a misbehaving feature (initial implementation + one feedback-driven fix) before stopping to do deeper research. READ before reaching for a third "let me try X" change in response to "still not working" feedback. Applies to any feature implementation, bug fix, or platform integration where the first observable test contradicts what the code was supposed to do.
+---
+
+# Iteration budget — research before the third attempt
+
+## The rule
+
+You get **two code attempts** at a misbehaving feature before you stop and do deeper research:
+
+1. **Attempt #1 — initial implementation.** Build the feature based on the spec/plan. Test it.
+2. **Attempt #2 — first feedback-driven fix.** User reports it doesn't work, you diagnose, you adjust, you ship the change. Test it again.
+
+If attempt #2 still doesn't work, **stop iterating on guesses**. Do real research before writing any more code:
+
+- Web search for prior art in the same problem class (e.g. "render HUD over fullscreen macOS app").
+- Read the canonical platform docs for the API you're using.
+- Look at how shipping apps in the same niche solved it.
+- Spawn a research agent (`general-purpose` or `Explore`) with a budget for breadth, not depth.
+
+Only after that research produces a concrete approach with a stated reason it should work — and ideally a citation that someone else has shipped it — do you write more code.
+
+## Why
+
+Two attempts is the right budget because:
+
+- **First attempt** is "what the spec said to do." Sometimes the spec is wrong. Worth one round of feedback to find out.
+- **Second attempt** is "obvious correction based on the new symptom." If the obvious correction also fails, the problem is no longer obvious — your model of the system is missing something the docs / community / OS-level docs would tell you, but local guessing won't.
+- **Third+ attempt without research** burns trust, cycle time, and dev-loop momentum. Iterations get smaller and more cargo-culted. The user can see the loop forming before you can. The 2nd→3rd→4th→5th pattern is recognizable from the outside as "thrashing."
+- The OpenWhisper codebase has hit this trap repeatedly on platform integrations (Tauri × macOS Spaces, WebView2 × WH_KEYBOARD_LL, AppKit × `acceptsFirstMouse`). In every case, 30 minutes of upfront research would have produced the right answer in one attempt; the multi-attempt loop produced wrong answers and a TASK-57-style "oops, that watchdog corrupted kernel state" entry in `openwhisper-platform-gotchas`.
+
+## How to apply
+
+When you ship a code change in response to "still not working" feedback, ask yourself: **is this my second attempt, or my third+?**
+
+- **2nd attempt** — fine, ship the obvious correction.
+- **3rd+ attempt** — STOP. Tell the user explicitly: *"Two attempts haven't worked. Pausing for research before next code change."* Then research. Don't write code in this turn.
+
+Treat it as a hard gate, not a heuristic. The temptation will be "I see the next thing to try, let me just do it" — that's the trap. The "next thing to try" after two failed attempts is almost always also wrong, because the failure mode you're modelling is wrong.
+
+The research itself can — and usually should — happen in a subagent so the main thread stays uncluttered. A `general-purpose` agent with a specific, source-naming prompt ("search Apple Developer Forums + tauri GitHub issues + indie Mac dev blogs for X; report under 600 words with cited URLs") is the standard shape.
+
+## What counts as "an attempt"
+
+- Writing code that you believe addresses the symptom, then asking the user to re-test → counts.
+- Reading more of the codebase / running a diagnostic command without changing code → does NOT count.
+- Adding logging / instrumentation to learn what's happening → does NOT count, this IS research.
+- Reverting your last change because it made things worse → does NOT count as a new attempt; the budget tracks forward attempts.
+
+If you're unsure whether your next change is "research-informed" or "another guess," default to it being a guess, and do the research first.
+
+## What "doing the research" looks like
+
+Not just "I'll think about it." Concrete:
+
+- A web search with terms specific to the failure mode, not the feature name.
+- Reading the actual platform source / docs you're calling into (e.g. tao's `set_visible_on_all_workspaces` impl, not Tauri's docs about it).
+- Looking at one or two shipping apps in the same niche to see what they did.
+- For platform-API issues: the relevant Apple Developer Forum thread / Microsoft Learn page / Tauri GitHub issue almost always exists; find it.
+
+The output of research should be: **one stated approach + one cited reason it should work** — *before* you change code. If you can't write that sentence, you haven't researched enough yet.
+
+## Boundary
+
+This rule does NOT apply to:
+
+- Multi-step features where each step is independently scoped (5 plan tasks, each with 1-2 attempts allowed). The budget resets per discrete sub-problem.
+- Refactors, cleanups, doc edits, or anything where there's no observable "does it work" check — those don't fit the iteration shape.
+- Type errors, lint errors, build errors — those are the compiler/linter telling you exactly what's wrong; just fix them.
+
+It applies specifically to: *feature implementations or bug fixes where the observable behavior is wrong, you wrote a fix, the observable behavior is still wrong, and you're tempted to write another fix.* That's the moment to stop.

--- a/.claude/skills/openwhisper-platform-gotchas/SKILL.md
+++ b/.claude/skills/openwhisper-platform-gotchas/SKILL.md
@@ -56,6 +56,20 @@ Open Tauri issues for the symptom (note: most discussions land on `acceptFirstMo
 
 ---
 
+### Plain NSWindow can't render over another app's fullscreen Space
+
+**Symptom:** The pill window has `alwaysOnTop: true` (Tauri → `NSFloatingWindowLevel`) and we set `NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorFullScreenAuxiliary | NSWindowCollectionBehaviorStationary` via objc2 `msg_send`, plus bumped the level to `NSStatusWindowLevel`. On Sonoma+ the pill still does not appear when another app is in fullscreen — it stays trapped on its origin Space and the fullscreen Space owner draws clean. Hotkey + paste flow still work; only the HUD doesn't render.
+
+**Root cause:** `fullScreenAuxiliary`'s documented contract is "may be shown on the same Space as the fullscreen window," not "above it" — see [Apple Developer Forums #26677](https://developer.apple.com/forums/thread/26677). Several panel-shape behaviors are silently ignored when set on `NSWindow` since Big Sur; the only reliable cross-app fullscreen-overlay path is to make the window a real `NSPanel` (subclass with `NSWindowStyleMask::nonactivatingPanel`) via objc class swizzle (`object_setClass`). Tauri's webview windows are `NSWindow`-backed by default; tao's `set_visible_on_all_workspaces` only flips the `canJoinAllSpaces` bit and doesn't touch the window class. Tauri's own issue tracker logs the same symptom ([tauri#11791](https://github.com/tauri-apps/tauri/issues/11791), closed as "use a panel"). Every shipping Tauri/Electron HUD that overlays cross-app fullscreen (Cap, Screenpipe, Hyprnote, Wispr Flow) goes through an NSPanel swizzle.
+
+**Fix in tree:** `apps/tauri/src-tauri/Cargo.toml` pulls `tauri-nspanel` (Mac-only, git dep on the `v2.1` branch). `apps/tauri/src-tauri/src/lib.rs` declares a `PillPanel` config via `tauri_panel!{}`, registers `tauri_nspanel::init()` on the builder, and converts the pill to a panel in `setup()` before any collection-behavior call (Floating level + nonactivating style mask). `apps/tauri/src-tauri/src/behavior.rs::apply_collection_behavior` drives the panel's `set_collection_behavior(can_join_all_spaces | full_screen_auxiliary)` when `behavior.show_in_fullscreen=true`, empty when false.
+
+**Windows impact:** None. Windows virtual desktops use a different model and `alwaysOnTop` already handles borderless-fullscreen overlay; exclusive-fullscreen DirectX is unsolvable from user-mode regardless. The `tauri-nspanel` dep is gated to `[target.'cfg(target_os = "macos")'.dependencies]`.
+
+**Do NOT** burn another iteration tweaking collection-behavior bits or window levels on a plain `NSWindow` if the symptom is "pill doesn't appear over another app's fullscreen". Two attempts (the `set_visible_on_all_workspaces` + objc2 `fullScreenAuxiliary` combo, then bumping to `NSStatusWindowLevel` + `Stationary`) confirmed both fail on Sonoma+ in this codebase before we found the real fix. The class swizzle is non-negotiable. Also do NOT hand-roll the swizzle in our own objc2 — `tauri-nspanel` is maintained, used by multiple shipping apps, and gives us free updates if Apple changes the underlying NSPanel ABI; rolling it ourselves trades ~30 lines we own for the same risk surface and no upside.
+
+---
+
 ## Cross-platform interface contracts
 
 When adding to this file, prefer the format:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,10 +2548,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2580,6 +2587,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-audio"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,6 +2618,17 @@ checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
  "bitflags 2.11.1",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2625,6 +2654,41 @@ dependencies = [
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-io-surface",
 ]
 
@@ -2758,6 +2822,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-nspanel",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "windows 0.61.3",
@@ -2854,6 +2919,12 @@ dependencies = [
  "smallvec 1.15.1",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pathdiff"
@@ -4407,6 +4478,18 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-nspanel"
+version = "2.1.0"
+source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v2.1#a3122e894383aa068ec5365a42994e3ac94ba1b6"
+dependencies = [
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "pastey",
+ "tauri",
 ]
 
 [[package]]

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -35,6 +35,13 @@ core-foundation = "0.10"
 # completion handler.
 objc2 = "0.6"
 block2 = "0.6"
+# Convert the pill webview window to a real NSPanel via objc class
+# swizzle so it can render over other apps' fullscreen Spaces. Plain
+# NSWindow + collection-behavior is unreliable cross-app on Sonoma+
+# (Apple Developer Forums #26677); tauri-nspanel is the canonical fix
+# used by Cap, Screenpipe, Hyprnote, Wispr Flow. v2.1 branch tracks
+# Tauri 2.10+.
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61", features = [

--- a/apps/tauri/src-tauri/src/behavior.rs
+++ b/apps/tauri/src-tauri/src/behavior.rs
@@ -1,0 +1,46 @@
+//! Behavior settings — currently the single `show_in_fullscreen` toggle
+//! that lets the user override OpenWhisper's automatic deactivation when
+//! another app is fullscreen on the focused screen.
+//!
+//! The fullscreen detector callback (registered in `lib.rs`) reads the
+//! AtomicBool cache on every transition without round-tripping through
+//! the settings file or the WebView. The setter command persists the
+//! value, updates the cache, and emits `behavior_show_in_fullscreen_changed`
+//! so React surfaces refresh and the lib.rs listener can reconcile pill
+//! visibility / hotkey state.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tauri::{AppHandle, Emitter};
+
+use crate::settings::{self, BehaviorSettings};
+
+static SHOW_IN_FULLSCREEN: AtomicBool = AtomicBool::new(false);
+
+pub fn show_in_fullscreen() -> bool {
+    SHOW_IN_FULLSCREEN.load(Ordering::Relaxed)
+}
+
+pub fn set_show_in_fullscreen_cache(value: bool) {
+    SHOW_IN_FULLSCREEN.store(value, Ordering::Relaxed);
+}
+
+#[tauri::command]
+pub fn behavior_get_show_in_fullscreen() -> bool {
+    show_in_fullscreen()
+}
+
+#[tauri::command]
+pub fn behavior_set_show_in_fullscreen(
+    app: AppHandle,
+    enabled: bool,
+) -> Result<(), String> {
+    settings::save_behavior_settings(
+        &app,
+        BehaviorSettings { show_in_fullscreen: enabled },
+    )?;
+    set_show_in_fullscreen_cache(enabled);
+    app.emit("behavior_show_in_fullscreen_changed", enabled)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/apps/tauri/src-tauri/src/behavior.rs
+++ b/apps/tauri/src-tauri/src/behavior.rs
@@ -11,7 +11,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 use crate::settings::{self, BehaviorSettings};
 
@@ -23,6 +23,21 @@ pub fn show_in_fullscreen() -> bool {
 
 pub fn set_show_in_fullscreen_cache(value: bool) {
     SHOW_IN_FULLSCREEN.store(value, Ordering::Relaxed);
+}
+
+/// Mirror `show_in_fullscreen` onto the pill window's `visibleOnAllWorkspaces`
+/// collection-behavior bit. On macOS this is the AppKit
+/// `canJoinAllSpaces`/`fullScreenAuxiliary` combo that lets the pill draw
+/// over fullscreen Spaces — without it, a normal-level window stays trapped
+/// in its origin Space and is invisible while a fullscreen app owns the
+/// screen. Tauri documents the call as a no-op on platforms that don't
+/// support it (Windows virtual desktops are a different model and the
+/// pill follows the active desktop already), so this is safe to call
+/// unconditionally.
+pub fn apply_collection_behavior(app: &AppHandle, show: bool) {
+    if let Some(pill) = app.get_webview_window("pill") {
+        let _ = pill.set_visible_on_all_workspaces(show);
+    }
 }
 
 #[tauri::command]

--- a/apps/tauri/src-tauri/src/behavior.rs
+++ b/apps/tauri/src-tauri/src/behavior.rs
@@ -11,7 +11,9 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter};
+#[cfg(not(target_os = "macos"))]
+use tauri::Manager;
 
 use crate::settings::{self, BehaviorSettings};
 
@@ -25,18 +27,43 @@ pub fn set_show_in_fullscreen_cache(value: bool) {
     SHOW_IN_FULLSCREEN.store(value, Ordering::Relaxed);
 }
 
-/// Mirror `show_in_fullscreen` onto the pill window's `visibleOnAllWorkspaces`
-/// collection-behavior bit. On macOS this is the AppKit
-/// `canJoinAllSpaces`/`fullScreenAuxiliary` combo that lets the pill draw
-/// over fullscreen Spaces — without it, a normal-level window stays trapped
-/// in its origin Space and is invisible while a fullscreen app owns the
-/// screen. Tauri documents the call as a no-op on platforms that don't
-/// support it (Windows virtual desktops are a different model and the
-/// pill follows the active desktop already), so this is safe to call
-/// unconditionally.
+/// Mirror `show_in_fullscreen` onto the pill panel's collection-behavior
+/// so it can render over other apps' fullscreen Spaces on macOS.
+///
+/// On macOS the pill is converted to an NSPanel at boot (see
+/// `lib.rs::setup`) and we drive its collection-behavior through the
+/// `tauri-nspanel` API rather than the underlying NSWindow's
+/// `set_visible_on_all_workspaces`: plain NSWindow with the same bits
+/// is unreliable on Sonoma+ when the fullscreen Space owner is
+/// another app (Apple Developer Forums #26677). The panel's
+/// `nonactivating_panel` style + `full_screen_auxiliary` +
+/// `can_join_all_spaces` is the canonical recipe shipped by Cap,
+/// Screenpipe, Hyprnote, Wispr Flow.
+///
+/// On non-macOS targets we fall back to the Tauri call, which is a
+/// no-op on platforms that don't support the workspace concept (the
+/// pill follows the active virtual desktop on Windows already).
 pub fn apply_collection_behavior(app: &AppHandle, show: bool) {
-    if let Some(pill) = app.get_webview_window("pill") {
-        let _ = pill.set_visible_on_all_workspaces(show);
+    #[cfg(target_os = "macos")]
+    {
+        use tauri_nspanel::{CollectionBehavior, ManagerExt};
+        let Ok(panel) = app.get_webview_panel("pill") else {
+            return;
+        };
+        let cb = if show {
+            CollectionBehavior::new()
+                .can_join_all_spaces()
+                .full_screen_auxiliary()
+        } else {
+            CollectionBehavior::new()
+        };
+        panel.set_collection_behavior(cb.into());
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(pill) = app.get_webview_window("pill") {
+            let _ = pill.set_visible_on_all_workspaces(show);
+        }
     }
 }
 

--- a/apps/tauri/src-tauri/src/fullscreen/mod.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mod.rs
@@ -37,6 +37,15 @@ type Callback = Box<dyn Fn(bool) + Send + Sync + 'static>;
 static CALLBACK: OnceLock<Callback> = OnceLock::new();
 static INSTALLED: AtomicBool = AtomicBool::new(false);
 
+/// Last-detected fullscreen state. The poll thread updates this on every
+/// tick whether or not the value changed. Consumers that need to
+/// re-evaluate gating outside of a transition (e.g. when the user toggles
+/// `behavior.show_in_fullscreen` while a fullscreen app is currently
+/// focused) read this without restarting the poller.
+pub fn is_active() -> bool {
+    ACTIVE.load(Ordering::Relaxed)
+}
+
 /// Register the change callback and start the poll thread. First call
 /// wins; subsequent calls are no-ops.
 pub fn install<F>(on_change: F)

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ use openwhisper_core::recognizer;
 use openwhisper_core::transcript;
 use openwhisper_core::verbose_log;
 use serde::Serialize;
-use tauri::{Emitter, LogicalPosition, Manager, WindowEvent};
+use tauri::{Emitter, Listener, LogicalPosition, Manager, WindowEvent};
 
 mod behavior;
 mod focus;
@@ -472,6 +472,27 @@ async fn position_pill_bottom_center(app: tauri::AppHandle) -> Result<(), String
         .map_err(|e| e.to_string())
 }
 
+/// Apply the gating side-effects for the current `(is_fullscreen, behavior::show_in_fullscreen)`
+/// pair. Called both from the fullscreen detector callback (on every
+/// transition) and from the `behavior_show_in_fullscreen_changed` event
+/// listener (when the user toggles the setting while focused on a
+/// fullscreen app). Suppression is the conjunction of "fullscreen
+/// detected" and "user has not opted out" — when suppressed, the pill
+/// hides, the global hotkey detaches, and an in-flight recording is
+/// silently aborted (`do_cancel` drops the audio buffer + transitions
+/// to IDLE without emitting a transcript, matching the spec's "don't
+/// surprise-paste into a fullscreen game" rule).
+fn apply_fullscreen_state(app: &tauri::AppHandle, is_fullscreen: bool) {
+    let suppress = is_fullscreen && !behavior::show_in_fullscreen();
+    hotkey::set_active(app, !suppress);
+    if let Some(pill) = app.get_webview_window("pill") {
+        let _ = if suppress { pill.hide() } else { pill.show() };
+    }
+    if suppress && dictation::is_recording() {
+        let _ = do_cancel();
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Single-instance MUST register on the Builder before .setup() runs:
@@ -583,12 +604,31 @@ pub fn run() {
             // the global hotkey so the fullscreen app receives Right Cmd /
             // Ctrl+Space normally, AND hide the pill so we don't paint over
             // games / videos / presentations. Re-arm on exit.
+            //
+            // Override: when `behavior.show_in_fullscreen` is true, the
+            // detector still observes transitions but the side-effects
+            // are skipped — pill stays visible, hotkey stays armed.
+            // Mid-recording fullscreen entry with the setting off aborts
+            // the recording silently (see `apply_fullscreen_state`).
             let app_for_fullscreen = app.handle().clone();
             fullscreen::install(move |is_fullscreen| {
-                hotkey::set_active(&app_for_fullscreen, !is_fullscreen);
-                if let Some(pill) = app_for_fullscreen.get_webview_window("pill") {
-                    let _ = if is_fullscreen { pill.hide() } else { pill.show() };
-                }
+                apply_fullscreen_state(&app_for_fullscreen, is_fullscreen);
+            });
+
+            // Reconcile pill + hotkey state when the user toggles
+            // `behavior.show_in_fullscreen` while a fullscreen app is
+            // currently focused. The setter has already updated the
+            // AtomicBool cache before emitting, so we just re-run the
+            // same logic against the latest detector state — flipping
+            // on while in fullscreen brings the pill back and re-arms
+            // the hotkey without restarting OW; flipping off with a
+            // recording in flight aborts it.
+            let app_for_behavior_event = app.handle().clone();
+            app.handle().listen("behavior_show_in_fullscreen_changed", move |_event| {
+                apply_fullscreen_state(
+                    &app_for_behavior_event,
+                    fullscreen::is_active(),
+                );
             });
             Ok(())
         })

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ use openwhisper_core::verbose_log;
 use serde::Serialize;
 use tauri::{Emitter, LogicalPosition, Manager, WindowEvent};
 
+mod behavior;
 mod focus;
 mod fullscreen;
 mod hotkey;
@@ -555,6 +556,11 @@ pub fn run() {
             // (rather than whatever cpal's default is on this boot).
             let audio_settings = settings::load_audio_settings(app.handle());
             audio::audio_set_selected_device_id(audio_settings.device_id);
+            // Hydrate the behavior AtomicBool cache before the fullscreen
+            // detector thread starts so the very first transition reads
+            // the persisted value rather than the default false.
+            let behavior_settings = settings::load_behavior_settings(app.handle());
+            behavior::set_show_in_fullscreen_cache(behavior_settings.show_in_fullscreen);
             hotkey::install(app.handle());
             // Proactively prompt for Mic on macOS once AX is operationally
             // trusted — mirrors PermissionsCoordinator.swift's "AX before
@@ -606,6 +612,8 @@ pub fn run() {
             audio_get_device_state,
             audio_preview_start,
             audio_preview_stop,
+            behavior::behavior_get_show_in_fullscreen,
+            behavior::behavior_set_show_in_fullscreen,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -502,12 +502,36 @@ async fn position_pill_bottom_center(app: tauri::AppHandle) -> Result<(), String
 fn apply_fullscreen_state(app: &tauri::AppHandle, is_fullscreen: bool) {
     let suppress = is_fullscreen && !behavior::show_in_fullscreen();
     hotkey::set_active(app, !suppress);
-    if let Some(pill) = app.get_webview_window("pill") {
-        let _ = if suppress { pill.hide() } else { pill.show() };
-    }
-    if suppress && dictation::is_recording() {
+    let was_recording = suppress && dictation::is_recording();
+    if was_recording {
         let _ = do_cancel();
     }
+    let Some(pill) = app.get_webview_window("pill") else {
+        return;
+    };
+    if !suppress {
+        let _ = pill.show();
+        return;
+    }
+    if !was_recording {
+        let _ = pill.hide();
+        return;
+    }
+    // Cancel ran but the pill webview is still rendering the recording
+    // frame. NSWindow orderOut caches the last-painted frame, so an
+    // immediate hide here means the next show — when the user exits
+    // fullscreen — paints those orange bars for one frame before
+    // React's IDLE tick lands. Defer the hide a couple of dictation
+    // ticks so React renders IDLE *while still visible*; the cached
+    // frame is then clean.
+    let pill_clone = pill.clone();
+    thread::Builder::new()
+        .name("openwhisper-pill-deferred-hide".into())
+        .spawn(move || {
+            thread::sleep(Duration::from_millis(120));
+            let _ = pill_clone.hide();
+        })
+        .expect("spawn pill deferred hide");
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -23,6 +23,23 @@ mod permissions;
 mod settings;
 mod tray;
 
+// The pill needs to be a real NSPanel (not NSWindow) so it can render
+// over other apps' fullscreen Spaces on macOS Sonoma+. tauri-nspanel
+// swizzles the window's class in place; the macro below declares the
+// panel config the conversion uses.
+#[cfg(target_os = "macos")]
+tauri_nspanel::tauri_panel! {
+    panel!(PillPanel {
+        config: {
+            // Pill never takes keyboard focus — the user's typing target
+            // is the app behind it. nonactivating style mask is set
+            // separately at conversion time.
+            can_become_key_window: false,
+            is_floating_panel: true
+        }
+    })
+}
+
 pub(crate) const TICK_MS: u64 = 50;
 const SAMPLE_RATE_HZ: u64 = 16_000;
 
@@ -512,6 +529,9 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_opener::init());
 
+    #[cfg(target_os = "macos")]
+    let builder = builder.plugin(tauri_nspanel::init());
+
     builder
         .setup(|app| {
             // Menu-bar-only — no Dock icon. Matches Superwhisper / Dropbox /
@@ -577,13 +597,32 @@ pub fn run() {
             // (rather than whatever cpal's default is on this boot).
             let audio_settings = settings::load_audio_settings(app.handle());
             audio::audio_set_selected_device_id(audio_settings.device_id);
+            // Convert the pill window to an NSPanel before any
+            // collection-behavior call — plain NSWindow can't reliably
+            // render on another app's fullscreen Space on Sonoma+
+            // regardless of the bits we set, so the swizzle has to
+            // happen first. Floating level + nonactivating style mask
+            // matches the Cap / Screenpipe / Hyprnote pattern.
+            #[cfg(target_os = "macos")]
+            {
+                use tauri_nspanel::{PanelLevel, StyleMask, WebviewWindowExt};
+                if let Some(pill_win) = app.get_webview_window("pill") {
+                    if let Ok(panel) = pill_win.to_panel::<PillPanel>() {
+                        panel.set_level(PanelLevel::Floating.value());
+                        panel.set_style_mask(
+                            StyleMask::empty().nonactivating_panel().into(),
+                        );
+                    }
+                }
+            }
+
             // Hydrate the behavior AtomicBool cache before the fullscreen
             // detector thread starts so the very first transition reads
             // the persisted value rather than the default false. Apply
-            // the pill's `visibleOnAllWorkspaces` collection-behavior at
-            // the same time so users who previously enabled the toggle
-            // get the expected over-fullscreen rendering on relaunch
-            // without having to flip the Switch again.
+            // the pill's collection-behavior at the same time so users
+            // who previously enabled the toggle get the expected
+            // over-fullscreen rendering on relaunch without having to
+            // flip the Switch again.
             let behavior_settings = settings::load_behavior_settings(app.handle());
             behavior::set_show_in_fullscreen_cache(behavior_settings.show_in_fullscreen);
             behavior::apply_collection_behavior(

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -579,9 +579,17 @@ pub fn run() {
             audio::audio_set_selected_device_id(audio_settings.device_id);
             // Hydrate the behavior AtomicBool cache before the fullscreen
             // detector thread starts so the very first transition reads
-            // the persisted value rather than the default false.
+            // the persisted value rather than the default false. Apply
+            // the pill's `visibleOnAllWorkspaces` collection-behavior at
+            // the same time so users who previously enabled the toggle
+            // get the expected over-fullscreen rendering on relaunch
+            // without having to flip the Switch again.
             let behavior_settings = settings::load_behavior_settings(app.handle());
             behavior::set_show_in_fullscreen_cache(behavior_settings.show_in_fullscreen);
+            behavior::apply_collection_behavior(
+                app.handle(),
+                behavior_settings.show_in_fullscreen,
+            );
             hotkey::install(app.handle());
             // Proactively prompt for Mic on macOS once AX is operationally
             // trusted — mirrors PermissionsCoordinator.swift's "AX before
@@ -624,7 +632,10 @@ pub fn run() {
             // the hotkey without restarting OW; flipping off with a
             // recording in flight aborts it.
             let app_for_behavior_event = app.handle().clone();
-            app.handle().listen("behavior_show_in_fullscreen_changed", move |_event| {
+            app.handle().listen("behavior_show_in_fullscreen_changed", move |event| {
+                let enabled = serde_json::from_str::<bool>(event.payload())
+                    .unwrap_or_else(|_| behavior::show_in_fullscreen());
+                behavior::apply_collection_behavior(&app_for_behavior_event, enabled);
                 apply_fullscreen_state(
                     &app_for_behavior_event,
                     fullscreen::is_active(),

--- a/apps/tauri/src-tauri/src/settings/mod.rs
+++ b/apps/tauri/src-tauri/src/settings/mod.rs
@@ -104,9 +104,9 @@ pub fn default_settings() -> HotkeySettings {
 
 /// On-disk schema. `hotkey` is the legacy single-slot field — kept for
 /// migration on first load after upgrading. `hotkeys` is the current
-/// shape; we always write that. `audio` is a sibling block that holds
-/// non-hotkey settings; absent on first run and on upgrades from the
-/// hotkey-only schema.
+/// shape; we always write that. `audio` and `behavior` are sibling blocks
+/// that hold non-hotkey settings; absent on first run and on upgrades
+/// from the hotkey-only schema.
 #[derive(Serialize, Deserialize, Default)]
 struct SettingsFile {
     #[serde(default)]
@@ -115,6 +115,8 @@ struct SettingsFile {
     hotkeys: Option<HotkeySettings>,
     #[serde(default)]
     audio: Option<AudioSettings>,
+    #[serde(default)]
+    behavior: Option<BehaviorSettings>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
@@ -129,8 +131,20 @@ pub struct AudioSettings {
     pub device_id: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct BehaviorSettings {
+    /// When true, OpenWhisper stays active over fullscreen apps — pill
+    /// remains visible (best-effort), hotkey stays armed. Default false
+    /// preserves the historical "step aside for games and video"
+    /// behavior. Read by the fullscreen detector callback via the
+    /// `behavior::SHOW_IN_FULLSCREEN` AtomicBool cache.
+    #[serde(default)]
+    pub show_in_fullscreen: bool,
+}
+
 static CURRENT: Mutex<Option<HotkeySettings>> = Mutex::new(None);
 static AUDIO_CURRENT: Mutex<Option<AudioSettings>> = Mutex::new(None);
+static BEHAVIOR_CURRENT: Mutex<Option<BehaviorSettings>> = Mutex::new(None);
 
 fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
@@ -190,10 +204,12 @@ pub fn current_settings() -> Option<HotkeySettings> {
 
 fn save_settings(app: &AppHandle, settings: HotkeySettings) -> Result<(), String> {
     let audio = current_audio_settings();
+    let behavior = current_behavior_settings();
     let file = SettingsFile {
         hotkey: None,
         hotkeys: Some(settings.clone()),
         audio,
+        behavior,
     };
     write_file(app, &file)?;
     if let Ok(mut g) = CURRENT.lock() {
@@ -228,13 +244,57 @@ fn save_audio_settings(app: &AppHandle, settings: AudioSettings) -> Result<(), S
     // by the user since boot.
     let file = read_file(app);
     let hotkeys = file.hotkeys.or_else(current_settings);
+    let behavior = file.behavior.or_else(current_behavior_settings);
     let merged = SettingsFile {
         hotkey: None,
         hotkeys,
         audio: Some(settings.clone()),
+        behavior,
     };
     write_file(app, &merged)?;
     if let Ok(mut g) = AUDIO_CURRENT.lock() {
+        *g = Some(settings);
+    }
+    Ok(())
+}
+
+pub fn current_behavior_settings() -> Option<BehaviorSettings> {
+    BEHAVIOR_CURRENT.lock().ok().and_then(|g| g.clone())
+}
+
+/// Load the behavior block from disk on the first call, then cache.
+/// Returns the default (show_in_fullscreen=false) when the file is
+/// absent or the behavior block is missing — same migration shape as
+/// `load_audio_settings`.
+pub fn load_behavior_settings(app: &AppHandle) -> BehaviorSettings {
+    if let Some(s) = BEHAVIOR_CURRENT.lock().ok().and_then(|g| g.clone()) {
+        return s;
+    }
+    let file = read_file(app);
+    let settings = file.behavior.unwrap_or_default();
+    if let Ok(mut g) = BEHAVIOR_CURRENT.lock() {
+        *g = Some(settings.clone());
+    }
+    settings
+}
+
+pub fn save_behavior_settings(
+    app: &AppHandle,
+    settings: BehaviorSettings,
+) -> Result<(), String> {
+    // Re-read for the same reason as `save_audio_settings`: avoid
+    // clobbering hotkey/audio blocks that may be newer than our cache.
+    let file = read_file(app);
+    let hotkeys = file.hotkeys.or_else(current_settings);
+    let audio = file.audio.or_else(current_audio_settings);
+    let merged = SettingsFile {
+        hotkey: None,
+        hotkeys,
+        audio,
+        behavior: Some(settings.clone()),
+    };
+    write_file(app, &merged)?;
+    if let Ok(mut g) = BEHAVIOR_CURRENT.lock() {
         *g = Some(settings);
     }
     Ok(())

--- a/apps/tauri/src/components/general-pane.tsx
+++ b/apps/tauri/src/components/general-pane.tsx
@@ -11,11 +11,14 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { Separator } from "@/components/ui/separator";
+import { useShowInFullscreen } from "@/lib/use-show-in-fullscreen";
 import { useTheme } from "@/lib/use-theme";
 
 export function GeneralPane() {
   const [launchAtLogin, setLaunchAtLogin] = useState(true);
   const { theme, setTheme } = useTheme();
+  const { enabled: showInFullscreen, setEnabled: setShowInFullscreen } =
+    useShowInFullscreen();
   const [version, setVersion] = useState<string | null>(null);
 
   useEffect(() => {
@@ -60,6 +63,29 @@ export function GeneralPane() {
           <ToggleGroupItem value="light">Light</ToggleGroupItem>
           <ToggleGroupItem value="dark">Dark</ToggleGroupItem>
         </ToggleGroup>
+      </Field>
+
+      <Separator />
+
+      <SectionHeader>Behavior</SectionHeader>
+      <Field orientation="horizontal">
+        <FieldContent>
+          <FieldLabel htmlFor="show-in-fullscreen">
+            Show in fullscreen apps
+          </FieldLabel>
+          <FieldDescription>
+            Keeps the pill visible and the hotkey active even when another
+            app is in fullscreen. Off by default — most users want
+            OpenWhisper to step aside for games and video.
+          </FieldDescription>
+        </FieldContent>
+        <Switch
+          id="show-in-fullscreen"
+          checked={showInFullscreen}
+          onCheckedChange={(next) => {
+            void setShowInFullscreen(next);
+          }}
+        />
       </Field>
 
       <Separator />

--- a/apps/tauri/src/lib/use-show-in-fullscreen.ts
+++ b/apps/tauri/src/lib/use-show-in-fullscreen.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+// Persists in core settings (not localStorage) so the Rust-side fullscreen
+// detector callback can read the boolean synchronously without invoking
+// through the WebView. The Switch in General → Behavior subscribes via
+// invoke for the initial read + listen for cross-surface updates emitted
+// by `behavior_set_show_in_fullscreen`.
+export function useShowInFullscreen() {
+  const [enabled, setEnabledState] = useState(false);
+
+  useEffect(() => {
+    invoke<boolean>("behavior_get_show_in_fullscreen")
+      .then(setEnabledState)
+      .catch(() => setEnabledState(false));
+  }, []);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    void listen<boolean>("behavior_show_in_fullscreen_changed", (event) =>
+      setEnabledState(event.payload),
+    ).then((fn) => {
+      unlisten = fn;
+    });
+    return () => unlisten?.();
+  }, []);
+
+  const setEnabled = (next: boolean) =>
+    invoke("behavior_set_show_in_fullscreen", { enabled: next });
+
+  return { enabled, setEnabled };
+}

--- a/apps/tauri/tests/fixtures/tauri-shim.ts
+++ b/apps/tauri/tests/fixtures/tauri-shim.ts
@@ -175,6 +175,23 @@ async function installTauriShim(page: Page, label: "main" = "main") {
           w.__owAudioSetCount = (w.__owAudioSetCount ?? 0) + 1;
           return null;
         }
+        if (cmd === "behavior_get_show_in_fullscreen") {
+          const w = window as unknown as { __owShowInFullscreen?: boolean };
+          return w.__owShowInFullscreen ?? false;
+        }
+        if (cmd === "behavior_set_show_in_fullscreen") {
+          const { enabled } = (args ?? {}) as { enabled: boolean };
+          const w = window as unknown as {
+            __owShowInFullscreen?: boolean;
+            __owShowInFullscreenLastSet?: boolean;
+            __owShowInFullscreenSetCount?: number;
+          };
+          w.__owShowInFullscreen = enabled;
+          w.__owShowInFullscreenLastSet = enabled;
+          w.__owShowInFullscreenSetCount =
+            (w.__owShowInFullscreenSetCount ?? 0) + 1;
+          return null;
+        }
         if (cmd === "audio_preview_start") {
           const w = window as unknown as { __owAudioPreviewStarts?: number };
           w.__owAudioPreviewStarts = (w.__owAudioPreviewStarts ?? 0) + 1;
@@ -236,6 +253,18 @@ async function installTauriShim(page: Page, label: "main" = "main") {
       return delivered;
     };
   }, label);
+}
+
+// Push a `behavior_show_in_fullscreen_changed` event at the
+// useShowInFullscreen subscriber. Mirrors the Rust setter's emit.
+export async function emitShowInFullscreenChanged(
+  page: Page,
+  enabled: boolean,
+): Promise<number> {
+  return page.evaluate(
+    (value) => window.__owEmit("behavior_show_in_fullscreen_changed", value),
+    enabled,
+  );
 }
 
 export async function emitTick(page: Page, tick: MockTick): Promise<number> {

--- a/apps/tauri/tests/settings-window.spec.ts
+++ b/apps/tauri/tests/settings-window.spec.ts
@@ -1,5 +1,6 @@
 import {
   emitDeviceState,
+  emitShowInFullscreenChanged,
   emitTick,
   expect,
   test,
@@ -72,6 +73,50 @@ test.describe("settings view", () => {
     await expect(
       page.getByRole("switch", { name: "Launch at login" }),
     ).toBeChecked();
+  });
+
+  test("Show in fullscreen Switch reflects behavior_get on mount", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      (window as unknown as { __owShowInFullscreen?: boolean }).__owShowInFullscreen =
+        true;
+    });
+    await openSettings(page);
+    await expect(
+      page.getByRole("switch", { name: "Show in fullscreen apps" }),
+    ).toBeChecked();
+  });
+
+  test("Toggling the Show in fullscreen Switch invokes behavior_set with the new value", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await openSettings(page);
+    const sw = page.getByRole("switch", { name: "Show in fullscreen apps" });
+    await expect(sw).not.toBeChecked();
+    await sw.click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __owShowInFullscreenLastSet?: boolean })
+              .__owShowInFullscreenLastSet,
+        ),
+      )
+      .toBe(true);
+  });
+
+  test("behavior_show_in_fullscreen_changed event updates the Show in fullscreen Switch", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await openSettings(page);
+    const sw = page.getByRole("switch", { name: "Show in fullscreen apps" });
+    await expect(sw).not.toBeChecked();
+    await emitShowInFullscreenChanged(page, true);
+    await expect(sw).toBeChecked();
   });
 
   test("Theme picker flips the dark/light class on <html>", async ({

--- a/backlog/tasks/task-58 - Setting-—-Show-in-fullscreen-apps-override-fullscreen-deactivation.md
+++ b/backlog/tasks/task-58 - Setting-—-Show-in-fullscreen-apps-override-fullscreen-deactivation.md
@@ -4,7 +4,7 @@ title: Setting — Show in fullscreen apps (override fullscreen deactivation)
 status: To Do
 assignee: []
 created_date: '2026-04-29 18:02'
-updated_date: '2026-04-29 18:05'
+updated_date: '2026-04-29 20:49'
 labels:
   - ui
   - tauri
@@ -24,10 +24,20 @@ Add a core setting that lets the user opt out of OW's automatic deactivation whe
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 New core setting behavior.show_in_fullscreen persists across boot; default false
-- [ ] #2 Setting=off preserves current behavior — pill hides, hotkey suppressed when foreground app on focused screen is fullscreen
-- [ ] #3 Setting=off + recording in flight: entering fullscreen aborts the recording silently — no transcript delivered, no paste, returns to idle
-- [ ] #4 Setting=on: pill stays visible (best-effort) and hotkey stays active when the foreground app is fullscreen; macOS pill collection-behavior allows overlaying fullscreen Spaces
-- [ ] #5 Settings → General has a Switch row for the toggle; reads/writes via core settings; reflects external changes via emitted event
-- [ ] #6 Playwright covers the toggle UI; existing Settings + General-pane tests still pass
+- [x] #1 New core setting behavior.show_in_fullscreen persists across boot; default false
+- [x] #2 Setting=off preserves current behavior — pill hides, hotkey suppressed when foreground app on focused screen is fullscreen
+- [x] #3 Setting=off + recording in flight: entering fullscreen aborts the recording silently — no transcript delivered, no paste, returns to idle
+- [x] #4 Setting=on: pill stays visible (best-effort) and hotkey stays active when the foreground app is fullscreen; macOS pill collection-behavior allows overlaying fullscreen Spaces
+- [x] #5 Settings → General has a Switch row for the toggle; reads/writes via core settings; reflects external changes via emitted event
+- [x] #6 Playwright covers the toggle UI; existing Settings + General-pane tests still pass
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+c7d50e6 Subtasks 58.1-58.5 all Done. cargo check clean, pnpm tsc --noEmit clean, pnpm test:ui 43/43 green. AC#2/#3/#4 require manual smoke (release build for setting=on path; dev build for off+idle, off+recording, toggle-on-during-fullscreen) — not verifiable from this shell, deferred to merge-time or user smoke pass.
+
+da26ad0+a982b42 fullscreen overlay verified via tauri-nspanel; learning captured in openwhisper-platform-gotchas + new openwhisper-iteration-budget skill
+
+fad1364 AC#2 + AC#3 verified manually after deferred-hide fix landed. All parent ACs now satisfied.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-58.1 - Plan-Task-1-Settings-schema-Rust-commands-in-process-cache.md
+++ b/backlog/tasks/task-58.1 - Plan-Task-1-Settings-schema-Rust-commands-in-process-cache.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-58.1
 title: 'Plan Task 1: Settings schema + Rust commands + in-process cache'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-04-29 18:05'
-updated_date: '2026-04-29 18:46'
+updated_date: '2026-04-29 18:49'
 labels:
   - 58-impl
 dependencies: []
@@ -14,9 +14,21 @@ parent_task_id: TASK-58
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 settings.rs schema includes show_in_fullscreen: bool with default false
-- [ ] #2 behavior.rs exposes show_in_fullscreen() reader, set_show_in_fullscreen_cache() writer, and the two Tauri commands
-- [ ] #3 behavior_set_show_in_fullscreen persists, updates cache, and emits behavior_show_in_fullscreen_changed with the new boolean
-- [ ] #4 Commands registered in generate_handler!; cache hydrated in setup() from loaded settings
-- [ ] #5 cargo check clean from apps/tauri/src-tauri/
+- [x] #1 settings.rs schema includes show_in_fullscreen: bool with default false
+- [x] #2 behavior.rs exposes show_in_fullscreen() reader, set_show_in_fullscreen_cache() writer, and the two Tauri commands
+- [x] #3 behavior_set_show_in_fullscreen persists, updates cache, and emits behavior_show_in_fullscreen_changed with the new boolean
+- [x] #4 Commands registered in generate_handler!; cache hydrated in setup() from loaded settings
+- [x] #5 cargo check clean from apps/tauri/src-tauri/
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+352ef8e TASK-58.1 schema + behavior.rs + lib.rs wiring; cargo check clean
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added BehaviorSettings persistence block (mirrors AudioSettings shape), new behavior.rs with AtomicBool cache + behavior_get/set_show_in_fullscreen Tauri commands emitting behavior_show_in_fullscreen_changed, and cache hydration in lib.rs setup(). cargo check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-58.1 - Plan-Task-1-Settings-schema-Rust-commands-in-process-cache.md
+++ b/backlog/tasks/task-58.1 - Plan-Task-1-Settings-schema-Rust-commands-in-process-cache.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-58.1
 title: 'Plan Task 1: Settings schema + Rust commands + in-process cache'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-04-29 18:05'
+updated_date: '2026-04-29 18:46'
 labels:
   - 58-impl
 dependencies: []

--- a/backlog/tasks/task-58.2 - Plan-Task-2-Detector-callback-honors-setting-abort-recording-on-fullscreen-entry.md
+++ b/backlog/tasks/task-58.2 - Plan-Task-2-Detector-callback-honors-setting-abort-recording-on-fullscreen-entry.md
@@ -3,9 +3,11 @@ id: TASK-58.2
 title: >-
   Plan Task 2: Detector callback honors setting; abort recording on
   fullscreen-entry
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 18:05'
+updated_date: '2026-04-29 20:49'
 labels:
   - 58-impl
 dependencies: []
@@ -14,8 +16,22 @@ parent_task_id: TASK-58
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Fullscreen callback reads behavior::show_in_fullscreen() and short-circuits when true
-- [ ] #2 Mid-recording fullscreen entry with setting=false aborts the recording silently — no transcript, no paste, returns to idle
-- [ ] #3 Toggling the setting while fullscreen is currently active immediately reconciles pill + hotkey state without restarting OW
-- [ ] #4 cargo check clean; manual smoke passes for the four cases (off+idle, off+recording, on+idle, toggle-on-during-fullscreen)
+- [x] #1 Fullscreen callback reads behavior::show_in_fullscreen() and short-circuits when true
+- [x] #2 Mid-recording fullscreen entry with setting=false aborts the recording silently — no transcript, no paste, returns to idle
+- [x] #3 Toggling the setting while fullscreen is currently active immediately reconciles pill + hotkey state without restarting OW
+- [x] #4 cargo check clean; manual smoke passes for the four cases (off+idle, off+recording, on+idle, toggle-on-during-fullscreen)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+0a474e5 detector callback + listener via apply_fullscreen_state; reused do_cancel for abort path (no new core API); cargo check clean. AC#4 manual smoke deferred to end-of-TASK-58 DoD pass.
+
+fad1364 defer pill.hide ~120ms after cancel so React renders IDLE before NSWindow orderOut caches the frame; eliminates orange-flash on fullscreen exit. AC#4 manual smoke verified end-to-end (off+idle, off+recording-with-clean-exit, on+idle, toggle-during-fullscreen).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fullscreen detector callback honors behavior::show_in_fullscreen, aborts mid-recording silently when suppressing, and reconciles state on toggle without restart. Deferred pill hide eliminates the orange-flash artifact on fullscreen exit.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-58.3 - Plan-Task-3-macOS-pill-collection-behavior-follows-the-setting.md
+++ b/backlog/tasks/task-58.3 - Plan-Task-3-macOS-pill-collection-behavior-follows-the-setting.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-58.3
 title: 'Plan Task 3: macOS pill collection-behavior follows the setting'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 18:05'
+updated_date: '2026-04-29 20:38'
 labels:
   - 58-impl
 dependencies: []
@@ -12,7 +14,21 @@ parent_task_id: TASK-58
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 macOS pill window's visible_on_all_workspaces mirrors the setting at boot and on every change
-- [ ] #2 Toggling on while a fullscreen app is active brings the pill into the fullscreen Space without restart
-- [ ] #3 Toggling off while in fullscreen reverts pill to normal Space behavior
+- [x] #1 macOS pill window's visible_on_all_workspaces mirrors the setting at boot and on every change
+- [x] #2 Toggling on while a fullscreen app is active brings the pill into the fullscreen Space without restart
+- [x] #3 Toggling off while in fullscreen reverts pill to normal Space behavior
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+df7c0d4 apply_collection_behavior helper, boot hydrate, listener wiring; cargo check clean. AC#2/#3 manual smoke deferred to end-of-TASK-58 DoD pass.
+
+a982b42 + da26ad0 NSWindow approach failed verification on Sonoma; pivoted to tauri-nspanel for NSPanel swizzle. Verified pill renders over fullscreen Claude Code terminal.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Pill panel collection-behavior follows the setting via tauri-nspanel (NSWindow path was unreliable cross-app on Sonoma+). Verified pill renders over another app's fullscreen Space.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-58.4 - Plan-Task-4-GeneralPane-Behavior-section-Switch-useShowInFullscreen-hook.md
+++ b/backlog/tasks/task-58.4 - Plan-Task-4-GeneralPane-Behavior-section-Switch-useShowInFullscreen-hook.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-58.4
 title: 'Plan Task 4: GeneralPane Behavior section + Switch + useShowInFullscreen hook'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 18:05'
+updated_date: '2026-04-29 18:54'
 labels:
   - 58-impl
 dependencies: []
@@ -12,8 +14,20 @@ parent_task_id: TASK-58
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 New use-show-in-fullscreen.ts hook uses invoke + listen, matching the project's Settings hook pattern
-- [ ] #2 General pane has a Switch row in a Behavior section (or merged into an existing section) with the spec's description copy
-- [ ] #3 Toggling the Switch persists, updates the cache, and is reflected back via the listen subscription
-- [ ] #4 pnpm tsc --noEmit clean
+- [x] #1 New use-show-in-fullscreen.ts hook uses invoke + listen, matching the project's Settings hook pattern
+- [x] #2 General pane has a Switch row in a Behavior section (or merged into an existing section) with the spec's description copy
+- [x] #3 Toggling the Switch persists, updates the cache, and is reflected back via the listen subscription
+- [x] #4 pnpm tsc --noEmit clean
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+1d90c96 new useShowInFullscreen hook + Behavior section (between Appearance and Updates) with Switch row; tsc --noEmit clean
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added useShowInFullscreen hook (invoke + listen) and a new General → Behavior section with a Switch row. tsc --noEmit clean.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-58.5 - Plan-Task-5-Playwright-spec-tauri-shim-stubs.md
+++ b/backlog/tasks/task-58.5 - Plan-Task-5-Playwright-spec-tauri-shim-stubs.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-58.5
 title: 'Plan Task 5: Playwright spec + tauri shim stubs'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 18:05'
+updated_date: '2026-04-29 18:55'
 labels:
   - 58-impl
 dependencies: []
@@ -12,8 +14,20 @@ parent_task_id: TASK-58
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tauri shim exposes stubs for the two behavior commands plus an emitShowInFullscreenChanged helper
-- [ ] #2 Three new tests assert: initial state from behavior_get, write-through via behavior_set, external event update via behavior_show_in_fullscreen_changed
-- [ ] #3 Existing Settings + General-pane tests still pass
-- [ ] #4 pnpm test:ui green locally and on CI
+- [x] #1 Tauri shim exposes stubs for the two behavior commands plus an emitShowInFullscreenChanged helper
+- [x] #2 Three new tests assert: initial state from behavior_get, write-through via behavior_set, external event update via behavior_show_in_fullscreen_changed
+- [x] #3 Existing Settings + General-pane tests still pass
+- [x] #4 pnpm test:ui green locally and on CI
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+c7d50e6 shim stubs + emitShowInFullscreenChanged helper + 3 new tests; pnpm test:ui 43/43 green
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added shim stubs for behavior_get/set_show_in_fullscreen, emitShowInFullscreenChanged helper, and three Playwright tests covering mount-state, click-through, and external-event update. pnpm test:ui 43/43 green.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary

- New `behavior.show_in_fullscreen` core setting (default `false`) lets users opt out of OpenWhisper's automatic deactivation when another app is fullscreen on the focused screen — pill stays visible, hotkey stays armed.
- Mid-recording fullscreen entry with the setting off aborts the recording silently (no transcript, no paste, returns to idle) instead of pasting transcribed text into a fullscreen game.
- Pill window converts to a real NSPanel via `tauri-nspanel` so it can render over another app's fullscreen Space on Sonoma+ (plain NSWindow + collection-behavior was unreliable cross-app — captured in `openwhisper-platform-gotchas`).
- Settings → General → new "Behavior" section with a Switch row, wired through a new `useShowInFullscreen` hook (invoke + listen, mirrors the `useTheme` shape).
- Deferred pill `hide()` after mid-recording cancel so the cached NSWindow frame on re-show is clean idle, not a one-frame orange-bars flash.
- New `openwhisper-iteration-budget` skill captures the meta-rule earned by this task: at most two code attempts on a misbehaving feature before stopping to do real research.

## Test plan

- [x] `cargo check` clean from `apps/tauri/src-tauri/`
- [x] `pnpm tsc --noEmit` clean from `apps/tauri/`
- [x] `pnpm test:ui` 43/43 green (3 new tests cover initial state, write-through, external-event update)
- [x] Manual smoke macOS: setting=off + idle → pill hides, hotkey suppressed
- [x] Manual smoke macOS: setting=off + recording → fullscreen entry aborts silently, no paste, clean idle on exit (no orange flash)
- [x] Manual smoke macOS: setting=on + idle → pill renders over fullscreen content, hotkey active
- [x] Manual smoke macOS: toggle on→off / off→on while in fullscreen reconciles state without restart
- [x] Manual smoke Windows: same matrix verified on Windows host

🤖 Generated with [Claude Code](https://claude.com/claude-code)