### PR TITLE
TASK-55: pill follows active screen + cross-DPI position fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "objc2",
+ "objc2-app-kit",
  "openwhisper-core",
  "serde",
  "serde_json",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -38,6 +38,10 @@ core-foundation = "0.10"
 # completion handler.
 objc2 = "0.6"
 block2 = "0.6"
+# NSScreen.visibleFrame for Dock-aware pill placement. Already in the
+# tree transitively via tauri-nspanel; promoted to a direct dep so we
+# can `use objc2_app_kit::NSScreen` without a re-export.
+objc2-app-kit = "0.3"
 # Convert the pill webview window to a real NSPanel via objc class
 # swizzle so it can render over other apps' fullscreen Spaces. Plain
 # NSWindow + collection-behavior is unreliable cross-app on Sonoma+

--- a/apps/tauri/src-tauri/src/fullscreen/mac.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mac.rs
@@ -138,6 +138,7 @@ pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
     let scale = monitor.scale_factor();
     let mon_x_log = monitor.position().x as f64 / scale;
     let mon_y_log = monitor.position().y as f64 / scale;
+    let mon_w_log = monitor.size().width as f64 / scale;
     let mon_h_log = monitor.size().height as f64 / scale;
     // Fallback used in every "can't determine work area" branch — the
     // bottom edge of the monitor itself, which is what `place_pill`
@@ -156,19 +157,27 @@ pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
     // screen's frame; we use that height to convert between Cocoa
     // (Y-up) and Quartz (Y-down).
     let primary_height_cocoa = primary.frame().size.height;
-    let mon_bottom_cocoa_y = primary_height_cocoa - (mon_y_log + mon_h_log);
+
+    // Match NSScreen by point-in-frame (using the monitor's centre in
+    // Quartz coords converted to Cocoa). This is more robust than
+    // matching by frame.origin equality across vertical multi-monitor
+    // arrangements where Cocoa and Quartz Y axes flip.
+    let cx_quartz = mon_x_log + mon_w_log / 2.0;
+    let cy_quartz = mon_y_log + mon_h_log / 2.0;
+    let cx_cocoa = cx_quartz;
+    let cy_cocoa = primary_height_cocoa - cy_quartz;
 
     for screen in screens.iter() {
         let frame = screen.frame();
-        if (frame.origin.x - mon_x_log).abs() < 1.0
-            && (frame.origin.y - mon_bottom_cocoa_y).abs() < 1.0
+        if cx_cocoa >= frame.origin.x
+            && cx_cocoa < frame.origin.x + frame.size.width
+            && cy_cocoa >= frame.origin.y
+            && cy_cocoa < frame.origin.y + frame.size.height
         {
-            // visibleFrame.origin.y in Cocoa is the Y of the *bottom*
-            // edge of the work area (Cocoa is Y-up; the work area's
-            // origin is at its bottom-left). Converting that to Quartz
-            // gives the Y of where the Dock starts (or the screen
-            // bottom when no Dock is on this screen).
             let vf = screen.visibleFrame();
+            // visibleFrame.origin.y in Cocoa is the Y of the bottom
+            // edge of the work area (Cocoa is Y-up; origin is at the
+            // bottom-left). Convert to Quartz Y-down.
             return primary_height_cocoa - vf.origin.y;
         }
     }

--- a/apps/tauri/src-tauri/src/fullscreen/mac.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mac.rs
@@ -28,6 +28,8 @@ use core_foundation::boolean::{CFBoolean, CFBooleanRef};
 use core_foundation::string::CFString;
 use core_graphics::display::CGDisplay;
 use core_graphics::geometry::CGPoint;
+use objc2::MainThreadMarker;
+use objc2_app_kit::NSScreen;
 use tauri::{AppHandle, Monitor};
 
 #[link(name = "ApplicationServices", kind = "framework")]
@@ -121,6 +123,56 @@ pub fn cursor_monitor() -> Option<(i32, i32)> {
         }
         None
     }
+}
+
+/// Y coordinate (logical-points, Quartz top-left origin, Y-down) of
+/// the bottom edge of the given monitor's work area — i.e. the top of
+/// the Dock when the Dock is on this screen, or the screen's bottom
+/// edge when not. Used by `place_pill` to anchor 24 px above the
+/// Dock. Falls back to the screen's own bottom edge if NSScreen
+/// enumeration can't match the given monitor.
+///
+/// MUST be called on the main thread: NSScreen is documented as
+/// main-thread-only by Apple.
+pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
+    let scale = monitor.scale_factor();
+    let mon_x_log = monitor.position().x as f64 / scale;
+    let mon_y_log = monitor.position().y as f64 / scale;
+    let mon_h_log = monitor.size().height as f64 / scale;
+    // Fallback used in every "can't determine work area" branch — the
+    // bottom edge of the monitor itself, which is what `place_pill`
+    // historically anchored to (minus a fixed 80 px margin).
+    let fallback = mon_y_log + mon_h_log;
+
+    // SAFETY: contract — caller is on the main thread (place_pill is
+    // dispatched via run_on_main_thread; the periodic refresh task
+    // also dispatches there).
+    let mtm = unsafe { MainThreadMarker::new_unchecked() };
+    let screens = NSScreen::screens(mtm);
+    let Some(primary) = screens.firstObject() else {
+        return fallback;
+    };
+    // Cocoa coordinate origin is the bottom-left of the primary
+    // screen's frame; we use that height to convert between Cocoa
+    // (Y-up) and Quartz (Y-down).
+    let primary_height_cocoa = primary.frame().size.height;
+    let mon_bottom_cocoa_y = primary_height_cocoa - (mon_y_log + mon_h_log);
+
+    for screen in screens.iter() {
+        let frame = screen.frame();
+        if (frame.origin.x - mon_x_log).abs() < 1.0
+            && (frame.origin.y - mon_bottom_cocoa_y).abs() < 1.0
+        {
+            // visibleFrame.origin.y in Cocoa is the Y of the *bottom*
+            // edge of the work area (Cocoa is Y-up; the work area's
+            // origin is at its bottom-left). Converting that to Quartz
+            // gives the Y of where the Dock starts (or the screen
+            // bottom when no Dock is on this screen).
+            let vf = screen.visibleFrame();
+            return primary_height_cocoa - vf.origin.y;
+        }
+    }
+    fallback
 }
 
 /// Convert the watcher's origin tuple (logical points from

--- a/apps/tauri/src-tauri/src/fullscreen/mac.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mac.rs
@@ -34,9 +34,6 @@ extern "C" {
         attribute: core_foundation::string::CFStringRef,
         value: *mut CFTypeRef,
     ) -> i32;
-    // Caller in TASK-55.4 (mod.rs poll tick) — silence the unused
-    // warning for the in-between commit.
-    #[allow(dead_code)]
     fn AXValueGetValue(
         value: CFTypeRef,
         the_type: u32,
@@ -47,15 +44,11 @@ extern "C" {
 const KAX_FOCUSED_APPLICATION: &str = "AXFocusedApplication";
 const KAX_FOCUSED_WINDOW: &str = "AXFocusedWindow";
 const KAX_FULL_SCREEN: &str = "AXFullScreen";
-#[allow(dead_code)]
 const KAX_POSITION: &str = "AXPosition";
-#[allow(dead_code)]
 const KAX_SIZE: &str = "AXSize";
 
 // AXValueType constants from <ApplicationServices/AXValue.h>.
-#[allow(dead_code)]
 const KAX_VALUE_CG_POINT_TYPE: u32 = 1;
-#[allow(dead_code)]
 const KAX_VALUE_CG_SIZE_TYPE: u32 = 2;
 
 pub fn is_fullscreen_now() -> bool {
@@ -109,7 +102,6 @@ unsafe fn copy_attr(element: CFTypeRef, attr: &str) -> Option<CFTypeRef> {
 /// position/size attributes can't be unpacked. Stable across ticks on a
 /// fixed display arrangement; the watcher in `mod.rs` only fires when
 /// the tuple changes.
-#[allow(dead_code)]
 pub fn focused_window_monitor() -> Option<(i32, i32)> {
     unsafe {
         let sys = AXUIElementCreateSystemWide();

--- a/apps/tauri/src-tauri/src/fullscreen/mac.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mac.rs
@@ -10,10 +10,21 @@
 //! AX is callable from any thread, so we run from the poller thread
 //! directly. AX permission is already granted via `hotkey::install`
 //! prompt.
+//!
+//! `focused_window_monitor()` reuses the same AX walk down to the
+//! focused window, then queries `kAXPositionAttribute` +
+//! `kAXSizeAttribute` (both packed as `AXValue` boxes — extracted via
+//! `AXValueGetValue`) and locates the display whose `CGDisplayBounds`
+//! rect contains the window's centre. Display enumeration uses
+//! `CGGetActiveDisplayList` (via the `core-graphics` crate's safe
+//! `CGDisplay::active_displays()`) which is callable from any thread —
+//! `NSScreen.screens` would NOT be (main-thread only).
 
 use core_foundation::base::{CFRelease, CFTypeRef, TCFType};
 use core_foundation::boolean::{CFBoolean, CFBooleanRef};
 use core_foundation::string::CFString;
+use core_graphics::display::CGDisplay;
+use core_graphics::geometry::{CGPoint, CGSize};
 
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
@@ -23,11 +34,29 @@ extern "C" {
         attribute: core_foundation::string::CFStringRef,
         value: *mut CFTypeRef,
     ) -> i32;
+    // Caller in TASK-55.4 (mod.rs poll tick) — silence the unused
+    // warning for the in-between commit.
+    #[allow(dead_code)]
+    fn AXValueGetValue(
+        value: CFTypeRef,
+        the_type: u32,
+        value_ptr: *mut std::ffi::c_void,
+    ) -> u8;
 }
 
 const KAX_FOCUSED_APPLICATION: &str = "AXFocusedApplication";
 const KAX_FOCUSED_WINDOW: &str = "AXFocusedWindow";
 const KAX_FULL_SCREEN: &str = "AXFullScreen";
+#[allow(dead_code)]
+const KAX_POSITION: &str = "AXPosition";
+#[allow(dead_code)]
+const KAX_SIZE: &str = "AXSize";
+
+// AXValueType constants from <ApplicationServices/AXValue.h>.
+#[allow(dead_code)]
+const KAX_VALUE_CG_POINT_TYPE: u32 = 1;
+#[allow(dead_code)]
+const KAX_VALUE_CG_SIZE_TYPE: u32 = 2;
 
 pub fn is_fullscreen_now() -> bool {
     unsafe {
@@ -67,6 +96,86 @@ unsafe fn copy_attr(element: CFTypeRef, attr: &str) -> Option<CFTypeRef> {
     if err == 0 && !value.is_null() {
         Some(value)
     } else {
+        None
+    }
+}
+
+/// Origin (top-left) of the display whose bounds contain the focused
+/// window's centre, in Quartz screen coordinates (primary display's
+/// top-left = `(0, 0)`, Y increases downward — same space
+/// `CGDisplayBounds` returns).
+///
+/// Returns `None` when AX is denied, no app/window has focus, or the
+/// position/size attributes can't be unpacked. Stable across ticks on a
+/// fixed display arrangement; the watcher in `mod.rs` only fires when
+/// the tuple changes.
+#[allow(dead_code)]
+pub fn focused_window_monitor() -> Option<(i32, i32)> {
+    unsafe {
+        let sys = AXUIElementCreateSystemWide();
+        if sys.is_null() {
+            return None;
+        }
+        let app = copy_attr(sys, KAX_FOCUSED_APPLICATION);
+        CFRelease(sys);
+        let app = app?;
+
+        let win = copy_attr(app, KAX_FOCUSED_WINDOW);
+        CFRelease(app);
+        let win = win?;
+
+        let pos_ref = copy_attr(win, KAX_POSITION);
+        let size_ref = copy_attr(win, KAX_SIZE);
+        CFRelease(win);
+
+        // Both refs must be released regardless of which (if any) is
+        // present — release on every branch.
+        let (pos, size) = match (pos_ref, size_ref) {
+            (Some(p), Some(s)) => {
+                let mut pos = CGPoint::new(0.0, 0.0);
+                let mut size = CGSize::new(0.0, 0.0);
+                let ok = AXValueGetValue(
+                    p,
+                    KAX_VALUE_CG_POINT_TYPE,
+                    &mut pos as *mut _ as *mut std::ffi::c_void,
+                ) != 0
+                    && AXValueGetValue(
+                        s,
+                        KAX_VALUE_CG_SIZE_TYPE,
+                        &mut size as *mut _ as *mut std::ffi::c_void,
+                    ) != 0;
+                CFRelease(p);
+                CFRelease(s);
+                if !ok {
+                    return None;
+                }
+                (pos, size)
+            }
+            (p, s) => {
+                if let Some(p) = p {
+                    CFRelease(p);
+                }
+                if let Some(s) = s {
+                    CFRelease(s);
+                }
+                return None;
+            }
+        };
+
+        let cx = pos.x + size.width / 2.0;
+        let cy = pos.y + size.height / 2.0;
+
+        let displays = CGDisplay::active_displays().ok()?;
+        for id in displays {
+            let bounds = CGDisplay::new(id).bounds();
+            let ox = bounds.origin.x;
+            let oy = bounds.origin.y;
+            let w = bounds.size.width;
+            let h = bounds.size.height;
+            if cx >= ox && cx < ox + w && cy >= oy && cy < oy + h {
+                return Some((ox as i32, oy as i32));
+            }
+        }
         None
     }
 }

--- a/apps/tauri/src-tauri/src/fullscreen/mac.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mac.rs
@@ -1,4 +1,5 @@
-//! macOS fullscreen detection via the Accessibility framework.
+//! macOS fullscreen detection via the Accessibility framework, plus
+//! cursor-monitor tracking for the pill-follow signal.
 //!
 //! `kAXFullScreenAttribute` on the focused window (reached via the system
 //! AX element) returns true when the active app is in macOS-native
@@ -11,20 +12,22 @@
 //! directly. AX permission is already granted via `hotkey::install`
 //! prompt.
 //!
-//! `focused_window_monitor()` reuses the same AX walk down to the
-//! focused window, then queries `kAXPositionAttribute` +
-//! `kAXSizeAttribute` (both packed as `AXValue` boxes — extracted via
-//! `AXValueGetValue`) and locates the display whose `CGDisplayBounds`
-//! rect contains the window's centre. Display enumeration uses
-//! `CGGetActiveDisplayList` (via the `core-graphics` crate's safe
-//! `CGDisplay::active_displays()`) which is callable from any thread —
-//! `NSScreen.screens` would NOT be (main-thread only).
+//! `cursor_monitor()` reads the cursor's current global-screen
+//! coordinates via `CGEventCreate(null)` + `CGEventGetLocation`, then
+//! locates the display whose `CGDisplayBounds` rect contains it. This
+//! replaced an earlier AX-based "focused window centre" approach that
+//! silently dropped Electron apps (Figma, Discord, VS Code) — those
+//! apps don't reliably expose `kAXPositionAttribute` / `kAXSizeAttribute`.
+//! The cursor-based approach matches Wispr Flow's pattern and works
+//! uniformly across Cocoa, Electron, and fullscreen contexts. Display
+//! enumeration uses `CGDisplay::active_displays()` which is callable
+//! from any thread — `NSScreen.screens` would NOT be (main-thread only).
 
 use core_foundation::base::{CFRelease, CFTypeRef, TCFType};
 use core_foundation::boolean::{CFBoolean, CFBooleanRef};
 use core_foundation::string::CFString;
 use core_graphics::display::CGDisplay;
-use core_graphics::geometry::{CGPoint, CGSize};
+use core_graphics::geometry::CGPoint;
 use tauri::{AppHandle, Monitor};
 
 #[link(name = "ApplicationServices", kind = "framework")]
@@ -35,22 +38,18 @@ extern "C" {
         attribute: core_foundation::string::CFStringRef,
         value: *mut CFTypeRef,
     ) -> i32;
-    fn AXValueGetValue(
-        value: CFTypeRef,
-        the_type: u32,
-        value_ptr: *mut std::ffi::c_void,
-    ) -> u8;
+    // Cursor-location FFI. Passing null source = "use a fresh default
+    // source" per Apple's CGEvent.h docs; CGEventGetLocation returns
+    // the cursor's current global-screen coordinates as a CGPoint
+    // (Quartz origin: primary display top-left = (0, 0), Y increases
+    // downward — same space `CGDisplayBounds` returns).
+    fn CGEventCreate(source: CFTypeRef) -> CFTypeRef;
+    fn CGEventGetLocation(event: CFTypeRef) -> CGPoint;
 }
 
 const KAX_FOCUSED_APPLICATION: &str = "AXFocusedApplication";
 const KAX_FOCUSED_WINDOW: &str = "AXFocusedWindow";
 const KAX_FULL_SCREEN: &str = "AXFullScreen";
-const KAX_POSITION: &str = "AXPosition";
-const KAX_SIZE: &str = "AXSize";
-
-// AXValueType constants from <ApplicationServices/AXValue.h>.
-const KAX_VALUE_CG_POINT_TYPE: u32 = 1;
-const KAX_VALUE_CG_SIZE_TYPE: u32 = 2;
 
 pub fn is_fullscreen_now() -> bool {
     unsafe {
@@ -94,69 +93,20 @@ unsafe fn copy_attr(element: CFTypeRef, attr: &str) -> Option<CFTypeRef> {
     }
 }
 
-/// Origin (top-left) of the display whose bounds contain the focused
-/// window's centre, in Quartz screen coordinates (primary display's
+/// Origin (top-left) of the display whose bounds contain the cursor's
+/// current location, in Quartz screen coordinates (primary display's
 /// top-left = `(0, 0)`, Y increases downward — same space
-/// `CGDisplayBounds` returns).
-///
-/// Returns `None` when AX is denied, no app/window has focus, or the
-/// position/size attributes can't be unpacked. Stable across ticks on a
-/// fixed display arrangement; the watcher in `mod.rs` only fires when
-/// the tuple changes.
-pub fn focused_window_monitor() -> Option<(i32, i32)> {
+/// `CGDisplayBounds` returns). Returns `None` only on a CG event-create
+/// or display-enumerate failure (extremely rare); the watcher's
+/// "skip when None" behavior keeps the pill where it is.
+pub fn cursor_monitor() -> Option<(i32, i32)> {
     unsafe {
-        let sys = AXUIElementCreateSystemWide();
-        if sys.is_null() {
+        let event = CGEventCreate(std::ptr::null());
+        if event.is_null() {
             return None;
         }
-        let app = copy_attr(sys, KAX_FOCUSED_APPLICATION);
-        CFRelease(sys);
-        let app = app?;
-
-        let win = copy_attr(app, KAX_FOCUSED_WINDOW);
-        CFRelease(app);
-        let win = win?;
-
-        let pos_ref = copy_attr(win, KAX_POSITION);
-        let size_ref = copy_attr(win, KAX_SIZE);
-        CFRelease(win);
-
-        // Both refs must be released regardless of which (if any) is
-        // present — release on every branch.
-        let (pos, size) = match (pos_ref, size_ref) {
-            (Some(p), Some(s)) => {
-                let mut pos = CGPoint::new(0.0, 0.0);
-                let mut size = CGSize::new(0.0, 0.0);
-                let ok = AXValueGetValue(
-                    p,
-                    KAX_VALUE_CG_POINT_TYPE,
-                    &mut pos as *mut _ as *mut std::ffi::c_void,
-                ) != 0
-                    && AXValueGetValue(
-                        s,
-                        KAX_VALUE_CG_SIZE_TYPE,
-                        &mut size as *mut _ as *mut std::ffi::c_void,
-                    ) != 0;
-                CFRelease(p);
-                CFRelease(s);
-                if !ok {
-                    return None;
-                }
-                (pos, size)
-            }
-            (p, s) => {
-                if let Some(p) = p {
-                    CFRelease(p);
-                }
-                if let Some(s) = s {
-                    CFRelease(s);
-                }
-                return None;
-            }
-        };
-
-        let cx = pos.x + size.width / 2.0;
-        let cy = pos.y + size.height / 2.0;
+        let pt = CGEventGetLocation(event);
+        CFRelease(event);
 
         let displays = CGDisplay::active_displays().ok()?;
         for id in displays {
@@ -165,7 +115,7 @@ pub fn focused_window_monitor() -> Option<(i32, i32)> {
             let oy = bounds.origin.y;
             let w = bounds.size.width;
             let h = bounds.size.height;
-            if cx >= ox && cx < ox + w && cy >= oy && cy < oy + h {
+            if pt.x >= ox && pt.x < ox + w && pt.y >= oy && pt.y < oy + h {
                 return Some((ox as i32, oy as i32));
             }
         }

--- a/apps/tauri/src-tauri/src/fullscreen/mac.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mac.rs
@@ -25,6 +25,7 @@ use core_foundation::boolean::{CFBoolean, CFBooleanRef};
 use core_foundation::string::CFString;
 use core_graphics::display::CGDisplay;
 use core_graphics::geometry::{CGPoint, CGSize};
+use tauri::{AppHandle, Monitor};
 
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
@@ -170,4 +171,28 @@ pub fn focused_window_monitor() -> Option<(i32, i32)> {
         }
         None
     }
+}
+
+/// Convert the watcher's origin tuple (logical points from
+/// `CGDisplayBounds.origin`) into the `tauri::Monitor` whose position
+/// matches. Tauri's `Monitor::position()` is physical px, so we
+/// convert the Tauri side to logical points by `/ scale_factor` and
+/// round — same form the watcher emits. Returns `None` if no monitor
+/// matches (e.g. display was unplugged between watcher tick and this
+/// call); the caller then falls back to `pill.current_monitor()`.
+///
+/// MUST be called on the main thread: Tauri's `available_monitors()`
+/// may go through `NSScreen.screens` internally, which is
+/// main-thread-only.
+pub fn find_tauri_monitor(app: &AppHandle, origin: (i32, i32)) -> Option<Monitor> {
+    let monitors = app.available_monitors().ok()?;
+    for m in monitors {
+        let scale = m.scale_factor();
+        let mx = (m.position().x as f64 / scale).round() as i32;
+        let my = (m.position().y as f64 / scale).round() as i32;
+        if (mx, my) == origin {
+            return Some(m);
+        }
+    }
+    None
 }

--- a/apps/tauri/src-tauri/src/fullscreen/mod.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mod.rs
@@ -1,7 +1,14 @@
-//! Fullscreen detection — fires a callback when the foreground app
-//! enters / exits fullscreen.
+//! Fullscreen + pill-follow detection — fires callbacks when the
+//! foreground app's fullscreen state or its hosting monitor changes.
 //!
-//! Consumer is `lib.rs` setup: register a callback once via [`install`].
+//! Two consumers, one poll thread:
+//! - Fullscreen callback (`install_fullscreen`) — registered by `lib.rs`
+//!   to drop the global hotkey and hide the pill while the user is in
+//!   a fullscreen app.
+//! - Pill-follow callback (`install_pill_follow`) — registered by
+//!   `lib.rs` to reposition the pill HUD onto the monitor hosting the
+//!   focused app. Gated by `settings::follow_active_screen()` so the
+//!   user's opt-out toggle is honored without restart.
 //!
 //! Implementation is poll-based (500 ms tick on a dedicated thread)
 //! rather than NSWorkspace / SetWinEventHook observer-driven. Reasons:
@@ -20,7 +27,7 @@
 //! changing the public API of this module.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
@@ -37,6 +44,14 @@ type Callback = Box<dyn Fn(bool) + Send + Sync + 'static>;
 static CALLBACK: OnceLock<Callback> = OnceLock::new();
 static INSTALLED: AtomicBool = AtomicBool::new(false);
 
+type MonitorCallback = Box<dyn Fn(Option<(i32, i32)>) + Send + Sync + 'static>;
+static MONITOR_CB: OnceLock<MonitorCallback> = OnceLock::new();
+/// Last-seen monitor origin so the callback only fires on actual
+/// changes. Deliberately NOT reset when `follow_active_screen` flips
+/// off — flipping back on should only trigger when the user genuinely
+/// changes monitor afterwards, not replay the current one.
+static LAST_MONITOR: Mutex<Option<(i32, i32)>> = Mutex::new(None);
+
 /// Last-detected fullscreen state. The poll thread updates this on every
 /// tick whether or not the value changed. Consumers that need to
 /// re-evaluate gating outside of a transition (e.g. when the user toggles
@@ -46,13 +61,36 @@ pub fn is_active() -> bool {
     ACTIVE.load(Ordering::Relaxed)
 }
 
-/// Register the change callback and start the poll thread. First call
-/// wins; subsequent calls are no-ops.
-pub fn install<F>(on_change: F)
+/// Register the fullscreen-state change callback and start the poll
+/// thread. First caller wins; subsequent calls re-register the
+/// callback but no-op the spawn.
+pub fn install_fullscreen<F>(on_change: F)
 where
     F: Fn(bool) + Send + Sync + 'static,
 {
     let _ = CALLBACK.set(Box::new(on_change));
+    ensure_poller_started();
+}
+
+/// Temporary alias — keeps `lib.rs`'s existing `fullscreen::install`
+/// call site compiling until TASK-55.5 swaps it for the new
+/// two-callback wiring.
+pub use install_fullscreen as install;
+
+/// Register the pill-follow callback. Fires `cb(Some(origin))` only
+/// when the focused window's hosting monitor's origin tuple changes
+/// AND the user has not opted out via `settings::follow_active_screen`.
+/// First-call-wins for the spawn; subsequent calls re-register.
+#[allow(dead_code)] // wired from lib.rs in TASK-55.5
+pub fn install_pill_follow<F>(on_change: F)
+where
+    F: Fn(Option<(i32, i32)>) + Send + Sync + 'static,
+{
+    let _ = MONITOR_CB.set(Box::new(on_change));
+    ensure_poller_started();
+}
+
+fn ensure_poller_started() {
     if INSTALLED
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_ok()
@@ -66,11 +104,29 @@ fn spawn_poller() {
         .name("openwhisper-fullscreen-poll".into())
         .spawn(|| loop {
             thread::sleep(POLL_INTERVAL);
+
             let cur = detect_now();
             let prev = ACTIVE.swap(cur, Ordering::Relaxed);
             if prev != cur {
                 if let Some(cb) = CALLBACK.get() {
                     cb(cur);
+                }
+            }
+
+            // Pill-follow signal: gated on the user setting so a flip
+            // to OFF stops firing immediately, no restart needed. We
+            // do NOT touch LAST_MONITOR while gated off — flipping
+            // back on therefore only fires when the user genuinely
+            // changes monitor afterwards.
+            if crate::settings::follow_active_screen() {
+                if let Some(origin) = focused_window_monitor() {
+                    let mut last = LAST_MONITOR.lock().unwrap();
+                    if *last != Some(origin) {
+                        *last = Some(origin);
+                        if let Some(cb) = MONITOR_CB.get() {
+                            cb(Some(origin));
+                        }
+                    }
                 }
             }
         })
@@ -90,4 +146,19 @@ fn detect_now() -> bool {
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn detect_now() -> bool {
     false
+}
+
+#[cfg(target_os = "macos")]
+fn focused_window_monitor() -> Option<(i32, i32)> {
+    mac::focused_window_monitor()
+}
+
+#[cfg(target_os = "windows")]
+fn focused_window_monitor() -> Option<(i32, i32)> {
+    windows::focused_window_monitor()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn focused_window_monitor() -> Option<(i32, i32)> {
+    None
 }

--- a/apps/tauri/src-tauri/src/fullscreen/mod.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mod.rs
@@ -31,6 +31,8 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
+use tauri::{AppHandle, Monitor};
+
 #[cfg(target_os = "macos")]
 mod mac;
 #[cfg(target_os = "windows")]
@@ -72,16 +74,10 @@ where
     ensure_poller_started();
 }
 
-/// Temporary alias — keeps `lib.rs`'s existing `fullscreen::install`
-/// call site compiling until TASK-55.5 swaps it for the new
-/// two-callback wiring.
-pub use install_fullscreen as install;
-
 /// Register the pill-follow callback. Fires `cb(Some(origin))` only
 /// when the focused window's hosting monitor's origin tuple changes
 /// AND the user has not opted out via `settings::follow_active_screen`.
 /// First-call-wins for the spawn; subsequent calls re-register.
-#[allow(dead_code)] // wired from lib.rs in TASK-55.5
 pub fn install_pill_follow<F>(on_change: F)
 where
     F: Fn(Option<(i32, i32)>) + Send + Sync + 'static,
@@ -160,5 +156,26 @@ fn focused_window_monitor() -> Option<(i32, i32)> {
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn focused_window_monitor() -> Option<(i32, i32)> {
+    None
+}
+
+/// Look up a `tauri::Monitor` by the origin tuple emitted by the
+/// watcher. Coordinate-space contract is opaque between layers — the
+/// platform module that produces the tuple is the same one that
+/// consumes it here, so each side handles its own physical/logical
+/// conversion. Caller must be on the main thread (mac path may go
+/// through `NSScreen.screens`).
+#[cfg(target_os = "macos")]
+pub fn find_tauri_monitor(app: &AppHandle, origin: (i32, i32)) -> Option<Monitor> {
+    mac::find_tauri_monitor(app, origin)
+}
+
+#[cfg(target_os = "windows")]
+pub fn find_tauri_monitor(app: &AppHandle, origin: (i32, i32)) -> Option<Monitor> {
+    windows::find_tauri_monitor(app, origin)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn find_tauri_monitor(_app: &AppHandle, _origin: (i32, i32)) -> Option<Monitor> {
     None
 }

--- a/apps/tauri/src-tauri/src/fullscreen/mod.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mod.rs
@@ -6,8 +6,8 @@
 //!   to drop the global hotkey and hide the pill while the user is in
 //!   a fullscreen app.
 //! - Pill-follow callback (`install_pill_follow`) — registered by
-//!   `lib.rs` to reposition the pill HUD onto the monitor hosting the
-//!   focused app. Gated by `settings::follow_active_screen()` so the
+//!   `lib.rs` to reposition the pill HUD onto the monitor under the
+//!   user's cursor. Gated by `settings::follow_active_screen()` so the
 //!   user's opt-out toggle is honored without restart.
 //!
 //! Implementation is poll-based (500 ms tick on a dedicated thread)
@@ -75,9 +75,9 @@ where
 }
 
 /// Register the pill-follow callback. Fires `cb(Some(origin))` only
-/// when the focused window's hosting monitor's origin tuple changes
-/// AND the user has not opted out via `settings::follow_active_screen`.
-/// First-call-wins for the spawn; subsequent calls re-register.
+/// when the cursor's monitor origin tuple changes AND the user has
+/// not opted out via `settings::follow_active_screen`. First-call-wins
+/// for the spawn; subsequent calls re-register.
 pub fn install_pill_follow<F>(on_change: F)
 where
     F: Fn(Option<(i32, i32)>) + Send + Sync + 'static,
@@ -115,7 +115,7 @@ fn spawn_poller() {
             // back on therefore only fires when the user genuinely
             // changes monitor afterwards.
             if crate::settings::follow_active_screen() {
-                if let Some(origin) = focused_window_monitor() {
+                if let Some(origin) = cursor_monitor() {
                     let mut last = LAST_MONITOR.lock().unwrap();
                     if *last != Some(origin) {
                         *last = Some(origin);
@@ -145,17 +145,17 @@ fn detect_now() -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn focused_window_monitor() -> Option<(i32, i32)> {
-    mac::focused_window_monitor()
+fn cursor_monitor() -> Option<(i32, i32)> {
+    mac::cursor_monitor()
 }
 
 #[cfg(target_os = "windows")]
-fn focused_window_monitor() -> Option<(i32, i32)> {
-    windows::focused_window_monitor()
+fn cursor_monitor() -> Option<(i32, i32)> {
+    windows::cursor_monitor()
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn focused_window_monitor() -> Option<(i32, i32)> {
+fn cursor_monitor() -> Option<(i32, i32)> {
     None
 }
 

--- a/apps/tauri/src-tauri/src/fullscreen/mod.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mod.rs
@@ -63,6 +63,17 @@ pub fn is_active() -> bool {
     ACTIVE.load(Ordering::Relaxed)
 }
 
+/// Watcher's last-emitted monitor origin (the display under the cursor at
+/// the most recent change). The periodic pill-refresh task uses this so it
+/// re-evaluates work-area changes (Dock resize) on the same display the
+/// watcher last followed — passing `None` would route through
+/// `pill.current_monitor()`, which on macOS can return the primary even
+/// after `set_position` placed the pill on the secondary, snapping the
+/// pill back every refresh tick.
+pub fn last_pill_monitor() -> Option<(i32, i32)> {
+    *LAST_MONITOR.lock().unwrap()
+}
+
 /// Register the fullscreen-state change callback and start the poll
 /// thread. First caller wins; subsequent calls re-register the
 /// callback but no-op the spawn.

--- a/apps/tauri/src-tauri/src/fullscreen/mod.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mod.rs
@@ -191,10 +191,14 @@ pub fn find_tauri_monitor(_app: &AppHandle, _origin: (i32, i32)) -> Option<Monit
     None
 }
 
-/// Y coordinate (logical points, Quartz top-left origin) of the
-/// bottom edge of the given monitor's work area. The pill anchors a
-/// fixed offset above this. Falls back to the monitor's own bottom
-/// edge if the platform query fails.
+/// Y coordinate (logical points, unified primary-relative coord space —
+/// top-left of primary = (0, 0), Y-down) of the bottom edge of the given
+/// monitor's work area. The pill anchors a fixed offset above this.
+/// Falls back to the monitor's own bottom edge if the platform query
+/// fails.
+///
+/// Logical-pt unit is load-bearing: callers using `LogicalPosition` /
+/// the platform-aware position helper expect this coord space.
 ///
 /// MUST be called on the main thread on macOS (NSScreen requirement);
 /// no thread restriction on Windows.

--- a/apps/tauri/src-tauri/src/fullscreen/mod.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/mod.rs
@@ -145,17 +145,17 @@ fn detect_now() -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn cursor_monitor() -> Option<(i32, i32)> {
+pub fn cursor_monitor() -> Option<(i32, i32)> {
     mac::cursor_monitor()
 }
 
 #[cfg(target_os = "windows")]
-fn cursor_monitor() -> Option<(i32, i32)> {
+pub fn cursor_monitor() -> Option<(i32, i32)> {
     windows::cursor_monitor()
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn cursor_monitor() -> Option<(i32, i32)> {
+pub fn cursor_monitor() -> Option<(i32, i32)> {
     None
 }
 
@@ -178,4 +178,27 @@ pub fn find_tauri_monitor(app: &AppHandle, origin: (i32, i32)) -> Option<Monitor
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub fn find_tauri_monitor(_app: &AppHandle, _origin: (i32, i32)) -> Option<Monitor> {
     None
+}
+
+/// Y coordinate (logical points, Quartz top-left origin) of the
+/// bottom edge of the given monitor's work area. The pill anchors a
+/// fixed offset above this. Falls back to the monitor's own bottom
+/// edge if the platform query fails.
+///
+/// MUST be called on the main thread on macOS (NSScreen requirement);
+/// no thread restriction on Windows.
+#[cfg(target_os = "macos")]
+pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
+    mac::work_area_bottom_y(monitor)
+}
+
+#[cfg(target_os = "windows")]
+pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
+    windows::work_area_bottom_y(monitor)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
+    let scale = monitor.scale_factor();
+    (monitor.position().y as f64 + monitor.size().height as f64) / scale
 }

--- a/apps/tauri/src-tauri/src/fullscreen/windows.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/windows.rs
@@ -82,33 +82,40 @@ fn window_class_name(hwnd: HWND) -> Option<String> {
     Some(String::from_utf16_lossy(&buf[..len as usize]))
 }
 
-pub fn is_fullscreen_now() -> bool {
+/// Foreground HWND + its window rect + the MONITORINFO of the
+/// containing monitor — `Some` only when no skip condition fires
+/// (invalid HWND, OW's own pid, shell-class window, or any GDI call
+/// failing). Both `is_fullscreen_now` and `focused_window_monitor`
+/// route through this; the HWND is in the tuple so the chromeless
+/// branch in `is_fullscreen_now` reads style bits from the same window
+/// that produced the rect (no second `GetForegroundWindow` race).
+fn foreground_monitor_info() -> Option<(HWND, RECT, MONITORINFO)> {
     unsafe {
         let fg = GetForegroundWindow();
         if fg.is_invalid() {
-            return false;
+            return None;
         }
 
         let mut pid: u32 = 0;
         GetWindowThreadProcessId(fg, Some(&mut pid));
         if pid == GetCurrentProcessId() {
-            return false;
+            return None;
         }
 
         if let Some(class) = window_class_name(fg) {
             if SHELL_CLASSES.iter().any(|c| *c == class) {
-                return false;
+                return None;
             }
         }
 
         let mut win_rect = RECT::default();
         if GetWindowRect(fg, &mut win_rect).is_err() {
-            return false;
+            return None;
         }
 
         let monitor = MonitorFromWindow(fg, MONITOR_DEFAULTTONEAREST);
         if monitor.is_invalid() {
-            return false;
+            return None;
         }
 
         let mut mi = MONITORINFO {
@@ -116,28 +123,47 @@ pub fn is_fullscreen_now() -> bool {
             ..Default::default()
         };
         if !GetMonitorInfoW(monitor, &mut mi).as_bool() {
-            return false;
+            return None;
         }
 
-        let covers_monitor = win_rect.left <= mi.rcMonitor.left
-            && win_rect.top <= mi.rcMonitor.top
-            && win_rect.right >= mi.rcMonitor.right
-            && win_rect.bottom >= mi.rcMonitor.bottom;
-        if !covers_monitor {
-            return false;
-        }
+        Some((fg, win_rect, mi))
+    }
+}
 
-        let chromeless = mi.rcWork.left == mi.rcMonitor.left
-            && mi.rcWork.top == mi.rcMonitor.top
-            && mi.rcWork.right == mi.rcMonitor.right
-            && mi.rcWork.bottom == mi.rcMonitor.bottom;
-        if !chromeless {
-            return true;
-        }
+pub fn is_fullscreen_now() -> bool {
+    let Some((fg, win_rect, mi)) = foreground_monitor_info() else {
+        return false;
+    };
 
+    let covers_monitor = win_rect.left <= mi.rcMonitor.left
+        && win_rect.top <= mi.rcMonitor.top
+        && win_rect.right >= mi.rcMonitor.right
+        && win_rect.bottom >= mi.rcMonitor.bottom;
+    if !covers_monitor {
+        return false;
+    }
+
+    let chromeless = mi.rcWork.left == mi.rcMonitor.left
+        && mi.rcWork.top == mi.rcMonitor.top
+        && mi.rcWork.right == mi.rcMonitor.right
+        && mi.rcWork.bottom == mi.rcMonitor.bottom;
+    if !chromeless {
+        return true;
+    }
+
+    unsafe {
         let style = GetWindowLongPtrW(fg, GWL_STYLE) as u32;
         let is_maximized = style & WS_MAXIMIZE.0 != 0;
         let has_chrome = style & (WS_CAPTION.0 | WS_THICKFRAME.0) != 0;
         !(is_maximized && has_chrome)
     }
+}
+
+/// Origin `(left, top)` of the monitor hosting the foreground window,
+/// in physical-px virtual-screen coordinates (same space as
+/// `MONITORINFO.rcMonitor`). Returns `None` when no foreground window
+/// qualifies — same skip list as `is_fullscreen_now`.
+#[allow(dead_code)]
+pub fn focused_window_monitor() -> Option<(i32, i32)> {
+    foreground_monitor_info().map(|(_, _, mi)| (mi.rcMonitor.left, mi.rcMonitor.top))
 }

--- a/apps/tauri/src-tauri/src/fullscreen/windows.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/windows.rs
@@ -190,6 +190,42 @@ pub fn cursor_monitor() -> Option<(i32, i32)> {
     }
 }
 
+/// Y coordinate (logical points; Quartz / virtual-screen top-left
+/// origin) of the bottom of the given monitor's work area — i.e. the
+/// top edge of the taskbar on this monitor, or the screen's bottom
+/// edge when the taskbar isn't present here. Falls back to the
+/// monitor's own bottom edge if `MonitorFromPoint` /
+/// `GetMonitorInfoW` fails.
+pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
+    let scale = monitor.scale_factor();
+    let mon_x = monitor.position().x;
+    let mon_y = monitor.position().y;
+    let mon_w = monitor.size().width as i32;
+    let mon_h = monitor.size().height as i32;
+    let fallback = (mon_y + mon_h) as f64 / scale;
+
+    let center = POINT {
+        x: mon_x + mon_w / 2,
+        y: mon_y + mon_h / 2,
+    };
+    unsafe {
+        let hmon = MonitorFromPoint(center, MONITOR_DEFAULTTONEAREST);
+        if hmon.is_invalid() {
+            return fallback;
+        }
+        let mut mi = MONITORINFO {
+            cbSize: size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        if !GetMonitorInfoW(hmon, &mut mi).as_bool() {
+            return fallback;
+        }
+        // rcWork is in physical pixels in virtual-screen coords; the
+        // pill placement math is in logical points.
+        mi.rcWork.bottom as f64 / scale
+    }
+}
+
 /// Look up the `tauri::Monitor` whose position matches the watcher's
 /// origin tuple. Both sides are physical px in virtual-screen
 /// coordinates on Windows, so a direct compare is correct — no

--- a/apps/tauri/src-tauri/src/fullscreen/windows.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/windows.rs
@@ -54,6 +54,7 @@
 
 use std::mem::size_of;
 
+use tauri::{AppHandle, Monitor};
 use windows::Win32::Foundation::{HWND, RECT};
 use windows::Win32::Graphics::Gdi::{
     GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
@@ -165,4 +166,19 @@ pub fn is_fullscreen_now() -> bool {
 /// qualifies — same skip list as `is_fullscreen_now`.
 pub fn focused_window_monitor() -> Option<(i32, i32)> {
     foreground_monitor_info().map(|(_, _, mi)| (mi.rcMonitor.left, mi.rcMonitor.top))
+}
+
+/// Look up the `tauri::Monitor` whose position matches the watcher's
+/// origin tuple. Both sides are physical px in virtual-screen
+/// coordinates on Windows, so a direct compare is correct — no
+/// conversion needed (unlike the macOS sibling).
+pub fn find_tauri_monitor(app: &AppHandle, origin: (i32, i32)) -> Option<Monitor> {
+    let monitors = app.available_monitors().ok()?;
+    for m in monitors {
+        let p = m.position();
+        if (p.x, p.y) == origin {
+            return Some(m);
+        }
+    }
+    None
 }

--- a/apps/tauri/src-tauri/src/fullscreen/windows.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/windows.rs
@@ -163,7 +163,6 @@ pub fn is_fullscreen_now() -> bool {
 /// in physical-px virtual-screen coordinates (same space as
 /// `MONITORINFO.rcMonitor`). Returns `None` when no foreground window
 /// qualifies — same skip list as `is_fullscreen_now`.
-#[allow(dead_code)]
 pub fn focused_window_monitor() -> Option<(i32, i32)> {
     foreground_monitor_info().map(|(_, _, mi)| (mi.rcMonitor.left, mi.rcMonitor.top))
 }

--- a/apps/tauri/src-tauri/src/fullscreen/windows.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/windows.rs
@@ -190,12 +190,11 @@ pub fn cursor_monitor() -> Option<(i32, i32)> {
     }
 }
 
-/// Y coordinate (logical points; Quartz / virtual-screen top-left
-/// origin) of the bottom of the given monitor's work area — i.e. the
-/// top edge of the taskbar on this monitor, or the screen's bottom
-/// edge when the taskbar isn't present here. Falls back to the
-/// monitor's own bottom edge if `MonitorFromPoint` /
-/// `GetMonitorInfoW` fails.
+/// Y coordinate (logical points, unified primary-relative coord space)
+/// of the bottom of the given monitor's work area — i.e. the top edge
+/// of the taskbar on this monitor, or the screen's bottom edge when
+/// the taskbar isn't here. Falls back to the monitor's own bottom edge
+/// if `MonitorFromPoint` / `GetMonitorInfoW` fails.
 pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
     let scale = monitor.scale_factor();
     let mon_x = monitor.position().x;
@@ -220,8 +219,8 @@ pub fn work_area_bottom_y(monitor: &Monitor) -> f64 {
         if !GetMonitorInfoW(hmon, &mut mi).as_bool() {
             return fallback;
         }
-        // rcWork is in physical pixels in virtual-screen coords; the
-        // pill placement math is in logical points.
+        // rcWork is in physical px in virtual-screen coords; pill placement
+        // math runs in logical pts.
         mi.rcWork.bottom as f64 / scale
     }
 }

--- a/apps/tauri/src-tauri/src/fullscreen/windows.rs
+++ b/apps/tauri/src-tauri/src/fullscreen/windows.rs
@@ -55,13 +55,14 @@
 use std::mem::size_of;
 
 use tauri::{AppHandle, Monitor};
-use windows::Win32::Foundation::{HWND, RECT};
+use windows::Win32::Foundation::{HWND, POINT, RECT};
 use windows::Win32::Graphics::Gdi::{
-    GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    GetMonitorInfoW, MonitorFromPoint, MonitorFromWindow, MONITORINFO,
+    MONITOR_DEFAULTTONEAREST,
 };
 use windows::Win32::System::Threading::GetCurrentProcessId;
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetClassNameW, GetForegroundWindow, GetWindowLongPtrW, GetWindowRect,
+    GetClassNameW, GetCursorPos, GetForegroundWindow, GetWindowLongPtrW, GetWindowRect,
     GetWindowThreadProcessId, GWL_STYLE, WS_CAPTION, WS_MAXIMIZE, WS_THICKFRAME,
 };
 
@@ -86,10 +87,9 @@ fn window_class_name(hwnd: HWND) -> Option<String> {
 /// Foreground HWND + its window rect + the MONITORINFO of the
 /// containing monitor — `Some` only when no skip condition fires
 /// (invalid HWND, OW's own pid, shell-class window, or any GDI call
-/// failing). Both `is_fullscreen_now` and `focused_window_monitor`
-/// route through this; the HWND is in the tuple so the chromeless
-/// branch in `is_fullscreen_now` reads style bits from the same window
-/// that produced the rect (no second `GetForegroundWindow` race).
+/// failing). Used by `is_fullscreen_now`; the HWND is in the tuple so
+/// the chromeless branch reads style bits from the same window that
+/// produced the rect (no second `GetForegroundWindow` race).
 fn foreground_monitor_info() -> Option<(HWND, RECT, MONITORINFO)> {
     unsafe {
         let fg = GetForegroundWindow();
@@ -160,12 +160,34 @@ pub fn is_fullscreen_now() -> bool {
     }
 }
 
-/// Origin `(left, top)` of the monitor hosting the foreground window,
-/// in physical-px virtual-screen coordinates (same space as
-/// `MONITORINFO.rcMonitor`). Returns `None` when no foreground window
-/// qualifies — same skip list as `is_fullscreen_now`.
-pub fn focused_window_monitor() -> Option<(i32, i32)> {
-    foreground_monitor_info().map(|(_, _, mi)| (mi.rcMonitor.left, mi.rcMonitor.top))
+/// Origin `(left, top)` of the monitor hosting the cursor, in
+/// physical-px virtual-screen coordinates (same space as
+/// `MONITORINFO.rcMonitor`). Returns `None` only on a `GetCursorPos`
+/// or `GetMonitorInfoW` failure (extremely rare).
+///
+/// Cursor-tracking replaced an earlier focused-window approach
+/// (TASK-55.3) which routed through `GetForegroundWindow` + AX-style
+/// window rect lookup. Cursor-based works uniformly across all app
+/// frameworks (Win32, Electron, UWP) and matches the macOS sibling.
+pub fn cursor_monitor() -> Option<(i32, i32)> {
+    unsafe {
+        let mut pt = POINT::default();
+        if GetCursorPos(&mut pt).is_err() {
+            return None;
+        }
+        let monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+        if monitor.is_invalid() {
+            return None;
+        }
+        let mut mi = MONITORINFO {
+            cbSize: size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        if !GetMonitorInfoW(monitor, &mut mi).as_bool() {
+            return None;
+        }
+        Some((mi.rcMonitor.left, mi.rcMonitor.top))
+    }
 }
 
 /// Look up the `tauri::Monitor` whose position matches the watcher's

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -404,6 +404,38 @@ fn spawn_dictation_emitter(app: tauri::AppHandle) {
         .expect("spawn dictation emitter");
 }
 
+/// Center the main window on the monitor under the user's cursor
+/// before showing it. Without this, the main window reappears on
+/// whichever monitor it was last hidden on, which is jarring when the
+/// user clicks the pill on a different display.
+///
+/// MUST be called on the main thread — `available_monitors()` and
+/// `outer_size()` go through main-thread-only paths on macOS.
+fn center_main_on_cursor_monitor(app: &tauri::AppHandle) {
+    let Some(main) = app.get_webview_window("main") else {
+        return;
+    };
+    let Some(origin) = fullscreen::cursor_monitor() else {
+        return;
+    };
+    let Some(monitor) = fullscreen::find_tauri_monitor(app, origin) else {
+        return;
+    };
+    let scale = monitor.scale_factor();
+    let mon_w = monitor.size().width as f64 / scale;
+    let mon_h = monitor.size().height as f64 / scale;
+    let mon_x = monitor.position().x as f64 / scale;
+    let mon_y = monitor.position().y as f64 / scale;
+
+    let Ok(size) = main.outer_size() else { return };
+    let win_w = size.width as f64 / scale;
+    let win_h = size.height as f64 / scale;
+
+    let x = mon_x + (mon_w - win_w) / 2.0;
+    let y = mon_y + (mon_h - win_h) / 2.0;
+    let _ = main.set_position(LogicalPosition::new(x, y));
+}
+
 /// Bring the main window forward — invoked when the pill is clicked in
 /// idle state. Mirrors the tray's `open_main` behavior so both entry points
 /// behave identically.
@@ -412,6 +444,10 @@ async fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
     let main = app
         .get_webview_window("main")
         .ok_or_else(|| "main window not found".to_string())?;
+    let app_clone = app.clone();
+    let _ = app
+        .run_on_main_thread(move || center_main_on_cursor_monitor(&app_clone))
+        .map_err(|e| e.to_string());
     main.show().map_err(|e| e.to_string())?;
     main.unminimize().map_err(|e| e.to_string())?;
     main.set_focus().map_err(|e| e.to_string())?;
@@ -426,6 +462,10 @@ async fn open_settings_window(app: tauri::AppHandle) -> Result<(), String> {
     let main = app
         .get_webview_window("main")
         .ok_or_else(|| "main window not found".to_string())?;
+    let app_clone = app.clone();
+    let _ = app
+        .run_on_main_thread(move || center_main_on_cursor_monitor(&app_clone))
+        .map_err(|e| e.to_string());
     main.show().map_err(|e| e.to_string())?;
     main.unminimize().map_err(|e| e.to_string())?;
     main.set_focus().map_err(|e| e.to_string())?;
@@ -446,12 +486,18 @@ async fn set_pill_click_through(
         .map_err(|e| e.to_string())
 }
 
-/// Place the pill bottom-center of a chosen monitor. The 80 px bottom
-/// margin is measured from the visible capsule edge, not the window
-/// edge — the window includes transparent padding so the CSS
-/// drop-shadow has room to render. Phase 7 will replace this with true
-/// work-area math (NSScreen.visibleFrame on Mac, GetMonitorInfo rcWork
-/// on Windows).
+/// Last (x, y) we passed to `pill.set_position` — used by `place_pill`
+/// to no-op when the periodic refresh task ticks but nothing changed.
+/// Logical points, Quartz top-left origin (matches `LogicalPosition`
+/// units passed to Tauri).
+static LAST_PILL_POSITION: Mutex<Option<(f64, f64)>> = Mutex::new(None);
+
+/// Place the pill bottom-center of a chosen monitor, anchored 24 px
+/// above the bottom edge of that monitor's *work area* — the top of
+/// the Dock on Mac, the top of the taskbar on Windows, or the screen's
+/// bottom edge when neither is on this monitor. Tracks Dock/taskbar
+/// resize via `fullscreen::work_area_bottom_y` (NSScreen.visibleFrame
+/// on Mac, MONITORINFO.rcWork on Windows).
 ///
 /// `monitor_origin` is opaque to this function: when `Some`, it gets
 /// passed straight to `fullscreen::find_tauri_monitor` which knows how
@@ -461,9 +507,15 @@ async fn set_pill_click_through(
 /// the watcher tick and this call — falls back to `current_monitor()`,
 /// then `primary_monitor()`, so the pill always lands somewhere.
 ///
-/// MUST be called on the main thread: `available_monitors()` may go
-/// through `NSScreen.screens` on macOS. Both the Tauri command wrapper
-/// and the watcher callback dispatch via `app.run_on_main_thread`.
+/// Self-dedupes via `LAST_PILL_POSITION`: skips the `set_position`
+/// call when the computed target equals the last one we set. The
+/// periodic refresh task in `setup()` therefore costs nothing while
+/// the user isn't moving the cursor or resizing the Dock.
+///
+/// MUST be called on the main thread: `available_monitors()` and
+/// `NSScreen.visibleFrame` are main-thread-only on macOS. Both the
+/// Tauri command wrapper and the watcher / refresh callbacks dispatch
+/// via `app.run_on_main_thread`.
 fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Result<(), String> {
     let pill = app
         .get_webview_window("pill")
@@ -477,9 +529,7 @@ fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Res
 
     let scale = monitor.scale_factor();
     let mon_w = monitor.size().width as f64 / scale;
-    let mon_h = monitor.size().height as f64 / scale;
     let mon_x = monitor.position().x as f64 / scale;
-    let mon_y = monitor.position().y as f64 / scale;
 
     // Window dimensions (must match tauri.conf.json pill window). Capsule
     // is centered inside the window via flex so the shadow has room on all
@@ -489,11 +539,27 @@ fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Res
     const PILL_WIN_H: f64 = 82.0;
     const CAPSULE_H: f64 = 22.0;
     const CAPSULE_BELOW_PAD: f64 = (PILL_WIN_H - CAPSULE_H) / 2.0;
-    const VISUAL_BOTTOM_MARGIN: f64 = 80.0;
+    /// Pixels between the visible capsule's bottom edge and the top
+    /// of the Dock / taskbar (or screen bottom when neither is here).
+    const ABOVE_DOCK_GAP: f64 = 24.0;
+
+    let work_area_bottom = fullscreen::work_area_bottom_y(&monitor);
 
     let x = mon_x + (mon_w - PILL_WIN_W) / 2.0;
-    // Solve: window_y + (PILL_WIN_H - CAPSULE_BELOW_PAD) = mon_h - VISUAL_BOTTOM_MARGIN
-    let y = mon_y + mon_h - VISUAL_BOTTOM_MARGIN - PILL_WIN_H + CAPSULE_BELOW_PAD;
+    // Solve: window_y + (PILL_WIN_H - CAPSULE_BELOW_PAD) = work_area_bottom - ABOVE_DOCK_GAP
+    let y = work_area_bottom - ABOVE_DOCK_GAP - PILL_WIN_H + CAPSULE_BELOW_PAD;
+
+    {
+        let mut last = LAST_PILL_POSITION.lock().unwrap();
+        // Sub-pixel jitter would otherwise cause needless `set_position`
+        // churn during periodic refresh. 0.5 px is below user-visible.
+        if let Some((lx, ly)) = *last {
+            if (lx - x).abs() < 0.5 && (ly - y).abs() < 0.5 {
+                return Ok(());
+            }
+        }
+        *last = Some((x, y));
+    }
 
     pill.set_position(LogicalPosition::new(x, y))
         .map_err(|e| e.to_string())
@@ -745,6 +811,31 @@ pub fn run() {
                     }
                 });
             });
+
+            // Dock / taskbar resize tracker. The cursor watcher fires
+            // on screen-cross only — but the user can grow/shrink the
+            // Mac Dock (or Win taskbar in auto-hide states) without
+            // ever crossing screens, in which case the pill would
+            // drift. Re-running place_pill on a 500 ms cadence picks
+            // up work-area changes; place_pill self-dedupes via
+            // LAST_PILL_POSITION so this is free when nothing moved.
+            let app_for_refresh = app.handle().clone();
+            thread::Builder::new()
+                .name("openwhisper-pill-refresh".into())
+                .spawn(move || loop {
+                    thread::sleep(Duration::from_millis(500));
+                    if !settings::follow_active_screen() {
+                        continue;
+                    }
+                    let app = app_for_refresh.clone();
+                    let app_inner = app.clone();
+                    let _ = app.run_on_main_thread(move || {
+                        if let Err(e) = place_pill(&app_inner, None) {
+                            eprintln!("[pill-refresh] {e}");
+                        }
+                    });
+                })
+                .expect("spawn pill refresh");
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -723,6 +723,8 @@ pub fn run() {
             settings::settings_capture_hotkey_start,
             settings::settings_capture_hotkey_cancel,
             settings::audio_set_device,
+            settings::settings_get_pill,
+            settings::settings_set_pill_follow,
             audio_get_device_state,
             audio_preview_start,
             audio_preview_stop,

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -12,7 +12,11 @@ use openwhisper_core::recognizer;
 use openwhisper_core::transcript;
 use openwhisper_core::verbose_log;
 use serde::Serialize;
-use tauri::{Emitter, Listener, LogicalPosition, Manager, WindowEvent};
+use tauri::{Emitter, Listener, Manager, WindowEvent};
+#[cfg(target_os = "macos")]
+use tauri::LogicalPosition;
+#[cfg(not(target_os = "macos"))]
+use tauri::PhysicalPosition;
 
 mod behavior;
 mod focus;
@@ -425,24 +429,60 @@ fn center_main_on_pill_monitor(app: &tauri::AppHandle) {
         })
         .or_else(|| pill.as_ref().and_then(|p| p.current_monitor().ok().flatten()));
     let Some(monitor) = monitor else { return };
-    // Monitor geometry uses the destination monitor's scale; the window's
-    // current size must use its OWN scale because `outer_size()` returns
-    // physical px relative to the monitor it's drawn on right now (which
-    // may differ from the destination — e.g. primary @2x → secondary @1x).
+    // Math in unified logical pts. See `place_pill` for why we dispatch
+    // `set_position` per platform via `set_window_at_logical`.
     let mon_scale = monitor.scale_factor();
-    let mon_w = monitor.size().width as f64 / mon_scale;
-    let mon_h = monitor.size().height as f64 / mon_scale;
     let mon_x = monitor.position().x as f64 / mon_scale;
     let mon_y = monitor.position().y as f64 / mon_scale;
+    let mon_w = monitor.size().width as f64 / mon_scale;
+    let mon_h = monitor.size().height as f64 / mon_scale;
 
     let Ok(size) = main.outer_size() else { return };
+    // `outer_size()` is physical px on the window's CURRENT monitor.
+    // Convert via the window's own scale to get logical-pt size — the
+    // value is invariant across monitors (Tauri auto-resizes on cross-DPI
+    // moves to keep logical dims constant).
     let win_scale = main.scale_factor().unwrap_or(mon_scale);
     let win_w = size.width as f64 / win_scale;
     let win_h = size.height as f64 / win_scale;
 
     let x = mon_x + (mon_w - win_w) / 2.0;
     let y = mon_y + (mon_h - win_h) / 2.0;
-    let _ = main.set_position(LogicalPosition::new(x, y));
+    let _ = set_window_at_logical(&main, x, y, mon_scale);
+}
+
+/// Position a window at logical-pt coords in the unified primary-relative
+/// coord space (top-left of primary = (0, 0), Y-down). Platform-aware
+/// because Tao's `set_outer_position` scales differently:
+///
+/// - macOS: takes a `LogicalPosition` verbatim (Cocoa Y conversion uses
+///   the primary screen's logical height — `CGDisplay::main().pixels_high`
+///   returns logical pts on Mac despite the name).
+/// - Windows: scales the position by the **window's current** scale
+///   factor, which is the *source* monitor's scale on a cross-DPI move.
+///   Pre-multiplying by the *destination* scale and passing
+///   `PhysicalPosition` sidesteps that.
+fn set_window_at_logical(
+    window: &tauri::WebviewWindow,
+    x_log: f64,
+    y_log: f64,
+    dest_scale: f64,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = dest_scale;
+        window
+            .set_position(LogicalPosition::new(x_log, y_log))
+            .map_err(|e| e.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let x_phys = (x_log * dest_scale).round() as i32;
+        let y_phys = (y_log * dest_scale).round() as i32;
+        window
+            .set_position(PhysicalPosition::new(x_phys, y_phys))
+            .map_err(|e| e.to_string())
+    }
 }
 
 /// Bring the main window forward — invoked when the pill is clicked in
@@ -536,32 +576,38 @@ fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Res
         .or_else(|| pill.primary_monitor().ok().flatten())
         .ok_or_else(|| "no monitor available".to_string())?;
 
+    // Math in unified LOGICAL pts (primary's top-left = origin, Y-down) —
+    // the same space `monitor.position() / monitor.scale_factor()` lands
+    // in. We dispatch `set_position` per-platform: Mac via
+    // `LogicalPosition` (Tao passes it verbatim and Cocoa Y is converted
+    // via primary's logical height), Win via `PhysicalPosition` computed
+    // from the *destination* monitor's scale (Tao on Win would otherwise
+    // scale a `LogicalPosition` by the **window's current** DPI factor —
+    // wrong axis when the window crosses monitors).
     let scale = monitor.scale_factor();
-    let mon_w = monitor.size().width as f64 / scale;
     let mon_x = monitor.position().x as f64 / scale;
     let mon_y = monitor.position().y as f64 / scale;
+    let mon_w = monitor.size().width as f64 / scale;
     let mon_h = monitor.size().height as f64 / scale;
     let mon_bottom = mon_y + mon_h;
 
-    // Window dimensions (must match tauri.conf.json pill window). Capsule
-    // is centered inside the window via flex so the shadow has room on all
-    // four sides — capsule visible bottom is `CAPSULE_BELOW_PAD` from the
-    // window's bottom edge.
+    // Pill window dimensions in logical points (must match tauri.conf.json).
+    // Capsule is centered inside the window via flex so the shadow has room
+    // on all four sides — capsule visible bottom is `CAPSULE_BELOW_PAD`
+    // from the window's bottom edge.
     const PILL_WIN_W: f64 = 130.0;
     const PILL_WIN_H: f64 = 82.0;
     const CAPSULE_H: f64 = 22.0;
     const CAPSULE_BELOW_PAD: f64 = (PILL_WIN_H - CAPSULE_H) / 2.0;
-    /// Pixels between the visible capsule's bottom edge and the top
-    /// of the Dock / taskbar when one is present.
+    /// Logical-pt gap between the capsule's bottom edge and the Dock /
+    /// taskbar when one is present on this screen.
     const ABOVE_DOCK_GAP: f64 = 24.0;
-    /// Larger gap when there's no Dock / taskbar on this screen — the
-    /// pill needs visible margin above the screen's bottom edge so it
-    /// doesn't sit at the seam between stacked monitors.
+    /// Logical-pt gap when no Dock / taskbar — the pill needs visible
+    /// margin above the screen's bottom edge so it doesn't sit at the
+    /// seam between stacked monitors.
     const ABOVE_BARE_EDGE_GAP: f64 = 80.0;
 
     let work_area_bottom = fullscreen::work_area_bottom_y(&monitor);
-    // No Dock / taskbar on this screen when the work area reaches the
-    // screen's actual bottom edge. Use the bigger gap in that case.
     let gap = if (work_area_bottom - mon_bottom).abs() < 1.0 {
         ABOVE_BARE_EDGE_GAP
     } else {
@@ -584,7 +630,7 @@ fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Res
         *last = Some((x, y));
     }
 
-    pill.set_position(LogicalPosition::new(x, y))
+    set_window_at_logical(&pill, x, y, scale)
         .map_err(|e| e.to_string())
 }
 

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -446,24 +446,34 @@ async fn set_pill_click_through(
         .map_err(|e| e.to_string())
 }
 
-/// Place the pill bottom-center of its current monitor. The 80 px bottom
-/// margin is measured from the visible capsule edge, not the window edge —
-/// the window includes transparent padding so the CSS drop-shadow has room
-/// to render. Phase 7 will replace this with true work-area math
-/// (NSScreen.visibleFrame on Mac, GetMonitorInfo rcWork on Windows).
-#[tauri::command]
-async fn position_pill_bottom_center(app: tauri::AppHandle) -> Result<(), String> {
+/// Place the pill bottom-center of a chosen monitor. The 80 px bottom
+/// margin is measured from the visible capsule edge, not the window
+/// edge — the window includes transparent padding so the CSS
+/// drop-shadow has room to render. Phase 7 will replace this with true
+/// work-area math (NSScreen.visibleFrame on Mac, GetMonitorInfo rcWork
+/// on Windows).
+///
+/// `monitor_origin` is opaque to this function: when `Some`, it gets
+/// passed straight to `fullscreen::find_tauri_monitor` which knows how
+/// to turn it back into a `tauri::Monitor` per platform (mac side
+/// converts logical→physical to match Tauri's coordinate space; win
+/// compares directly). On no-match — e.g. display unplugged between
+/// the watcher tick and this call — falls back to `current_monitor()`,
+/// then `primary_monitor()`, so the pill always lands somewhere.
+///
+/// MUST be called on the main thread: `available_monitors()` may go
+/// through `NSScreen.screens` on macOS. Both the Tauri command wrapper
+/// and the watcher callback dispatch via `app.run_on_main_thread`.
+fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Result<(), String> {
     let pill = app
         .get_webview_window("pill")
         .ok_or_else(|| "pill window not found".to_string())?;
 
-    let monitor = match pill.current_monitor().map_err(|e| e.to_string())? {
-        Some(m) => m,
-        None => pill
-            .primary_monitor()
-            .map_err(|e| e.to_string())?
-            .ok_or_else(|| "no monitor available".to_string())?,
-    };
+    let monitor = monitor_origin
+        .and_then(|origin| fullscreen::find_tauri_monitor(app, origin))
+        .or_else(|| pill.current_monitor().ok().flatten())
+        .or_else(|| pill.primary_monitor().ok().flatten())
+        .ok_or_else(|| "no monitor available".to_string())?;
 
     let scale = monitor.scale_factor();
     let mon_w = monitor.size().width as f64 / scale;
@@ -532,6 +542,20 @@ fn apply_fullscreen_state(app: &tauri::AppHandle, is_fullscreen: bool) {
             let _ = pill_clone.hide();
         })
         .expect("spawn pill deferred hide");
+}
+
+#[tauri::command]
+async fn reposition_pill(
+    app: tauri::AppHandle,
+    monitor_origin: Option<(i32, i32)>,
+) -> Result<(), String> {
+    let app_clone = app.clone();
+    app.run_on_main_thread(move || {
+        if let Err(e) = place_pill(&app_clone, monitor_origin) {
+            eprintln!("[reposition_pill] {e}");
+        }
+    })
+    .map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -682,7 +706,7 @@ pub fn run() {
             // Mid-recording fullscreen entry with the setting off aborts
             // the recording silently (see `apply_fullscreen_state`).
             let app_for_fullscreen = app.handle().clone();
-            fullscreen::install(move |is_fullscreen| {
+            fullscreen::install_fullscreen(move |is_fullscreen| {
                 apply_fullscreen_state(&app_for_fullscreen, is_fullscreen);
             });
 
@@ -704,6 +728,23 @@ pub fn run() {
                     fullscreen::is_active(),
                 );
             });
+
+            // Pill-follow: reposition the HUD onto the monitor hosting the
+            // focused app whenever it changes. The watcher already gates
+            // itself on settings::follow_active_screen() so we don't have
+            // to. run_on_main_thread is load-bearing — Tauri's
+            // available_monitors() may reach NSScreen.screens internally
+            // on macOS, which is main-thread-only.
+            let app_for_pill = app.handle().clone();
+            fullscreen::install_pill_follow(move |origin| {
+                let app = app_for_pill.clone();
+                let app_inner = app.clone();
+                let _ = app.run_on_main_thread(move || {
+                    if let Err(e) = place_pill(&app_inner, origin) {
+                        eprintln!("[pill-follow] {e}");
+                    }
+                });
+            });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -711,7 +752,7 @@ pub fn run() {
             dictation_toggle,
             dictation_cancel,
             set_pill_click_through,
-            position_pill_bottom_center,
+            reposition_pill,
             show_main_window,
             open_settings_window,
             hotkey::hotkey_retry,

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -404,32 +404,41 @@ fn spawn_dictation_emitter(app: tauri::AppHandle) {
         .expect("spawn dictation emitter");
 }
 
-/// Center the main window on the monitor under the user's cursor
-/// before showing it. Without this, the main window reappears on
-/// whichever monitor it was last hidden on, which is jarring when the
-/// user clicks the pill on a different display.
+/// Center the main window on the monitor that hosts the pill (the
+/// screen the user just clicked from). Falls back to the cursor's
+/// monitor — and finally the pill's reported `current_monitor` — so
+/// non-follow users (no `LAST_MONITOR` recorded) still get centered
+/// placement instead of "wherever main was last hidden".
 ///
 /// MUST be called on the main thread — `available_monitors()` and
 /// `outer_size()` go through main-thread-only paths on macOS.
-fn center_main_on_cursor_monitor(app: &tauri::AppHandle) {
+fn center_main_on_pill_monitor(app: &tauri::AppHandle) {
     let Some(main) = app.get_webview_window("main") else {
         return;
     };
-    let Some(origin) = fullscreen::cursor_monitor() else {
-        return;
-    };
-    let Some(monitor) = fullscreen::find_tauri_monitor(app, origin) else {
-        return;
-    };
-    let scale = monitor.scale_factor();
-    let mon_w = monitor.size().width as f64 / scale;
-    let mon_h = monitor.size().height as f64 / scale;
-    let mon_x = monitor.position().x as f64 / scale;
-    let mon_y = monitor.position().y as f64 / scale;
+    let pill = app.get_webview_window("pill");
+    let monitor = fullscreen::last_pill_monitor()
+        .and_then(|origin| fullscreen::find_tauri_monitor(app, origin))
+        .or_else(|| {
+            fullscreen::cursor_monitor()
+                .and_then(|origin| fullscreen::find_tauri_monitor(app, origin))
+        })
+        .or_else(|| pill.as_ref().and_then(|p| p.current_monitor().ok().flatten()));
+    let Some(monitor) = monitor else { return };
+    // Monitor geometry uses the destination monitor's scale; the window's
+    // current size must use its OWN scale because `outer_size()` returns
+    // physical px relative to the monitor it's drawn on right now (which
+    // may differ from the destination — e.g. primary @2x → secondary @1x).
+    let mon_scale = monitor.scale_factor();
+    let mon_w = monitor.size().width as f64 / mon_scale;
+    let mon_h = monitor.size().height as f64 / mon_scale;
+    let mon_x = monitor.position().x as f64 / mon_scale;
+    let mon_y = monitor.position().y as f64 / mon_scale;
 
     let Ok(size) = main.outer_size() else { return };
-    let win_w = size.width as f64 / scale;
-    let win_h = size.height as f64 / scale;
+    let win_scale = main.scale_factor().unwrap_or(mon_scale);
+    let win_w = size.width as f64 / win_scale;
+    let win_h = size.height as f64 / win_scale;
 
     let x = mon_x + (mon_w - win_w) / 2.0;
     let y = mon_y + (mon_h - win_h) / 2.0;
@@ -446,7 +455,7 @@ async fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
         .ok_or_else(|| "main window not found".to_string())?;
     let app_clone = app.clone();
     let _ = app
-        .run_on_main_thread(move || center_main_on_cursor_monitor(&app_clone))
+        .run_on_main_thread(move || center_main_on_pill_monitor(&app_clone))
         .map_err(|e| e.to_string());
     main.show().map_err(|e| e.to_string())?;
     main.unminimize().map_err(|e| e.to_string())?;
@@ -464,7 +473,7 @@ async fn open_settings_window(app: tauri::AppHandle) -> Result<(), String> {
         .ok_or_else(|| "main window not found".to_string())?;
     let app_clone = app.clone();
     let _ = app
-        .run_on_main_thread(move || center_main_on_cursor_monitor(&app_clone))
+        .run_on_main_thread(move || center_main_on_pill_monitor(&app_clone))
         .map_err(|e| e.to_string());
     main.show().map_err(|e| e.to_string())?;
     main.unminimize().map_err(|e| e.to_string())?;
@@ -530,6 +539,9 @@ fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Res
     let scale = monitor.scale_factor();
     let mon_w = monitor.size().width as f64 / scale;
     let mon_x = monitor.position().x as f64 / scale;
+    let mon_y = monitor.position().y as f64 / scale;
+    let mon_h = monitor.size().height as f64 / scale;
+    let mon_bottom = mon_y + mon_h;
 
     // Window dimensions (must match tauri.conf.json pill window). Capsule
     // is centered inside the window via flex so the shadow has room on all
@@ -540,14 +552,25 @@ fn place_pill(app: &tauri::AppHandle, monitor_origin: Option<(i32, i32)>) -> Res
     const CAPSULE_H: f64 = 22.0;
     const CAPSULE_BELOW_PAD: f64 = (PILL_WIN_H - CAPSULE_H) / 2.0;
     /// Pixels between the visible capsule's bottom edge and the top
-    /// of the Dock / taskbar (or screen bottom when neither is here).
+    /// of the Dock / taskbar when one is present.
     const ABOVE_DOCK_GAP: f64 = 24.0;
+    /// Larger gap when there's no Dock / taskbar on this screen — the
+    /// pill needs visible margin above the screen's bottom edge so it
+    /// doesn't sit at the seam between stacked monitors.
+    const ABOVE_BARE_EDGE_GAP: f64 = 80.0;
 
     let work_area_bottom = fullscreen::work_area_bottom_y(&monitor);
+    // No Dock / taskbar on this screen when the work area reaches the
+    // screen's actual bottom edge. Use the bigger gap in that case.
+    let gap = if (work_area_bottom - mon_bottom).abs() < 1.0 {
+        ABOVE_BARE_EDGE_GAP
+    } else {
+        ABOVE_DOCK_GAP
+    };
 
     let x = mon_x + (mon_w - PILL_WIN_W) / 2.0;
-    // Solve: window_y + (PILL_WIN_H - CAPSULE_BELOW_PAD) = work_area_bottom - ABOVE_DOCK_GAP
-    let y = work_area_bottom - ABOVE_DOCK_GAP - PILL_WIN_H + CAPSULE_BELOW_PAD;
+    // Solve: window_y + (PILL_WIN_H - CAPSULE_BELOW_PAD) = work_area_bottom - gap
+    let y = work_area_bottom - gap - PILL_WIN_H + CAPSULE_BELOW_PAD;
 
     {
         let mut last = LAST_PILL_POSITION.lock().unwrap();
@@ -829,8 +852,9 @@ pub fn run() {
                     }
                     let app = app_for_refresh.clone();
                     let app_inner = app.clone();
+                    let origin = fullscreen::last_pill_monitor();
                     let _ = app.run_on_main_thread(move || {
-                        if let Err(e) = place_pill(&app_inner, None) {
+                        if let Err(e) = place_pill(&app_inner, origin) {
                             eprintln!("[pill-refresh] {e}");
                         }
                     });

--- a/apps/tauri/src-tauri/src/settings/mod.rs
+++ b/apps/tauri/src-tauri/src/settings/mod.rs
@@ -11,6 +11,7 @@
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
@@ -104,9 +105,9 @@ pub fn default_settings() -> HotkeySettings {
 
 /// On-disk schema. `hotkey` is the legacy single-slot field — kept for
 /// migration on first load after upgrading. `hotkeys` is the current
-/// shape; we always write that. `audio` and `behavior` are sibling blocks
-/// that hold non-hotkey settings; absent on first run and on upgrades
-/// from the hotkey-only schema.
+/// shape; we always write that. `audio`, `behavior`, and `pill` are
+/// sibling blocks that hold non-hotkey settings; absent on first run
+/// and on upgrades from the hotkey-only schema.
 #[derive(Serialize, Deserialize, Default)]
 struct SettingsFile {
     #[serde(default)]
@@ -117,6 +118,21 @@ struct SettingsFile {
     audio: Option<AudioSettings>,
     #[serde(default)]
     behavior: Option<BehaviorSettings>,
+    #[serde(default)]
+    pill: Option<PillSettings>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct PillSettings {
+    /// Pill HUD jumps to the monitor hosting the focused app on every
+    /// foreground change. ON by default — opt-out toggle, not opt-in.
+    pub follow_active_screen: bool,
+}
+
+impl Default for PillSettings {
+    fn default() -> Self {
+        Self { follow_active_screen: true }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
@@ -145,6 +161,20 @@ pub struct BehaviorSettings {
 static CURRENT: Mutex<Option<HotkeySettings>> = Mutex::new(None);
 static AUDIO_CURRENT: Mutex<Option<AudioSettings>> = Mutex::new(None);
 static BEHAVIOR_CURRENT: Mutex<Option<BehaviorSettings>> = Mutex::new(None);
+/// Process-global mirror of `pill.follow_active_screen`. The watcher
+/// thread reads this lock-free on every 500 ms tick — a `Mutex` would
+/// be fine but the access pattern (read-mostly, write-on-toggle) makes
+/// `AtomicBool` the right primitive. Defaults to `true` so a fresh
+/// checkout (no settings.json) gets follow-on behavior.
+static FOLLOW_ACTIVE_SCREEN: AtomicBool = AtomicBool::new(true);
+
+pub fn follow_active_screen() -> bool {
+    FOLLOW_ACTIVE_SCREEN.load(Ordering::Relaxed)
+}
+
+pub fn current_pill_settings() -> PillSettings {
+    PillSettings { follow_active_screen: follow_active_screen() }
+}
 
 fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
@@ -186,11 +216,16 @@ fn merge_loaded(file: SettingsFile) -> HotkeySettings {
 
 /// Load saved hotkeys (with migration from the legacy single-slot field)
 /// or fall back to platform defaults. Caches the result for backends.
+/// Side-effect: hydrates `FOLLOW_ACTIVE_SCREEN` from the same on-disk
+/// read, so the pill watcher sees the persisted value on its first
+/// poll tick after boot.
 pub fn load_settings(app: &AppHandle) -> HotkeySettings {
     if let Some(s) = CURRENT.lock().ok().and_then(|g| g.clone()) {
         return s;
     }
     let file = read_file(app);
+    let pill = file.pill.clone().unwrap_or_default();
+    FOLLOW_ACTIVE_SCREEN.store(pill.follow_active_screen, Ordering::Relaxed);
     let settings = merge_loaded(file);
     if let Ok(mut g) = CURRENT.lock() {
         *g = Some(settings.clone());
@@ -210,6 +245,7 @@ fn save_settings(app: &AppHandle, settings: HotkeySettings) -> Result<(), String
         hotkeys: Some(settings.clone()),
         audio,
         behavior,
+        pill: Some(current_pill_settings()),
     };
     write_file(app, &file)?;
     if let Ok(mut g) = CURRENT.lock() {
@@ -239,17 +275,19 @@ pub fn load_audio_settings(app: &AppHandle) -> AudioSettings {
 }
 
 fn save_audio_settings(app: &AppHandle, settings: AudioSettings) -> Result<(), String> {
-    // Re-read the on-disk file so we don't clobber an audio-or-hotkey
-    // block that is newer than our cache. Hotkeys may have been written
-    // by the user since boot.
+    // Re-read the on-disk file so we don't clobber a sibling block that
+    // is newer than our cache. Hotkeys / behavior / pill may all have
+    // been written by the user since boot.
     let file = read_file(app);
     let hotkeys = file.hotkeys.or_else(current_settings);
     let behavior = file.behavior.or_else(current_behavior_settings);
+    let pill = file.pill.or_else(|| Some(current_pill_settings()));
     let merged = SettingsFile {
         hotkey: None,
         hotkeys,
         audio: Some(settings.clone()),
         behavior,
+        pill,
     };
     write_file(app, &merged)?;
     if let Ok(mut g) = AUDIO_CURRENT.lock() {
@@ -283,15 +321,18 @@ pub fn save_behavior_settings(
     settings: BehaviorSettings,
 ) -> Result<(), String> {
     // Re-read for the same reason as `save_audio_settings`: avoid
-    // clobbering hotkey/audio blocks that may be newer than our cache.
+    // clobbering hotkey/audio/pill blocks that may be newer than our
+    // cache.
     let file = read_file(app);
     let hotkeys = file.hotkeys.or_else(current_settings);
     let audio = file.audio.or_else(current_audio_settings);
+    let pill = file.pill.or_else(|| Some(current_pill_settings()));
     let merged = SettingsFile {
         hotkey: None,
         hotkeys,
         audio,
         behavior: Some(settings.clone()),
+        pill,
     };
     write_file(app, &merged)?;
     if let Ok(mut g) = BEHAVIOR_CURRENT.lock() {
@@ -363,4 +404,33 @@ pub fn audio_set_device(app: AppHandle, id: Option<String>) -> Result<(), String
     save_audio_settings(&app, settings)?;
     openwhisper_core::audio::audio_set_selected_device_id(normalized);
     Ok(())
+}
+
+fn save_pill_settings(app: &AppHandle, settings: PillSettings) -> Result<(), String> {
+    // Re-read disk so a hotkey/audio/behavior change written between
+    // boot and this call survives. Same shape as save_audio_settings.
+    let file = read_file(app);
+    let hotkeys = file.hotkeys.or_else(current_settings);
+    let audio = file.audio.or_else(current_audio_settings);
+    let behavior = file.behavior.or_else(current_behavior_settings);
+    let merged = SettingsFile {
+        hotkey: None,
+        hotkeys,
+        audio,
+        behavior,
+        pill: Some(settings.clone()),
+    };
+    write_file(app, &merged)?;
+    FOLLOW_ACTIVE_SCREEN.store(settings.follow_active_screen, Ordering::Relaxed);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn settings_get_pill(_app: AppHandle) -> PillSettings {
+    current_pill_settings()
+}
+
+#[tauri::command]
+pub fn settings_set_pill_follow(app: AppHandle, follow: bool) -> Result<(), String> {
+    save_pill_settings(&app, PillSettings { follow_active_screen: follow })
 }

--- a/apps/tauri/src/PillOverlay.tsx
+++ b/apps/tauri/src/PillOverlay.tsx
@@ -198,9 +198,9 @@ export function PillOverlay() {
   }, [renderedStatus]);
 
   useEffect(() => {
-    invoke("position_pill_bottom_center").catch(
+    invoke("reposition_pill", { monitor_origin: null }).catch(
       // eslint-disable-next-line no-console
-      (e) => console.warn("position_pill_bottom_center failed", e),
+      (e) => console.warn("reposition_pill failed", e),
     );
   }, []);
 

--- a/apps/tauri/src/components/general-pane.tsx
+++ b/apps/tauri/src/components/general-pane.tsx
@@ -14,18 +14,36 @@ import { Separator } from "@/components/ui/separator";
 import { useShowInFullscreen } from "@/lib/use-show-in-fullscreen";
 import { useTheme } from "@/lib/use-theme";
 
+type PillSettings = { follow_active_screen: boolean };
+
 export function GeneralPane() {
   const [launchAtLogin, setLaunchAtLogin] = useState(true);
   const { theme, setTheme } = useTheme();
   const { enabled: showInFullscreen, setEnabled: setShowInFullscreen } =
     useShowInFullscreen();
   const [version, setVersion] = useState<string | null>(null);
+  const [followActiveScreen, setFollowActiveScreen] = useState(true);
 
   useEffect(() => {
     invoke<string>("core_version")
       .then(setVersion)
       .catch(() => setVersion(null));
   }, []);
+
+  useEffect(() => {
+    invoke<PillSettings>("settings_get_pill")
+      .then((s) => setFollowActiveScreen(s.follow_active_screen))
+      .catch(() => setFollowActiveScreen(true));
+  }, []);
+
+  const onFollowChange = (next: boolean) => {
+    setFollowActiveScreen(next);
+    invoke("settings_set_pill_follow", { follow: next }).catch((e) => {
+      // eslint-disable-next-line no-console
+      console.warn("settings_set_pill_follow failed", e);
+      setFollowActiveScreen(!next);
+    });
+  };
 
   return (
     <FieldGroup className="px-1 py-2">
@@ -85,6 +103,25 @@ export function GeneralPane() {
           onCheckedChange={(next) => {
             void setShowInFullscreen(next);
           }}
+        />
+      </Field>
+
+      <Separator />
+
+      <SectionHeader>Pill</SectionHeader>
+      <Field orientation="horizontal">
+        <FieldContent>
+          <FieldLabel htmlFor="follow-active-screen">
+            Follow active screen
+          </FieldLabel>
+          <FieldDescription>
+            Pill jumps to whichever screen has the focused app.
+          </FieldDescription>
+        </FieldContent>
+        <Switch
+          id="follow-active-screen"
+          checked={followActiveScreen}
+          onCheckedChange={onFollowChange}
         />
       </Field>
 

--- a/apps/tauri/tests/fixtures/tauri-shim.ts
+++ b/apps/tauri/tests/fixtures/tauri-shim.ts
@@ -202,6 +202,28 @@ async function installTauriShim(page: Page, label: "main" = "main") {
           w.__owAudioPreviewStops = (w.__owAudioPreviewStops ?? 0) + 1;
           return null;
         }
+        if (cmd === "settings_get_pill") {
+          const stored = (window as unknown as { __owPillFollow?: boolean })
+            .__owPillFollow;
+          return { follow_active_screen: stored ?? true };
+        }
+        if (cmd === "settings_set_pill_follow") {
+          const { follow } = (args ?? {}) as { follow: boolean };
+          const w = window as unknown as {
+            __owPillFollow?: boolean;
+            __owPillSetCount?: number;
+            __owPillLastFollow?: boolean;
+          };
+          w.__owPillFollow = follow;
+          w.__owPillLastFollow = follow;
+          w.__owPillSetCount = (w.__owPillSetCount ?? 0) + 1;
+          return null;
+        }
+        if (cmd === "reposition_pill") {
+          // PillOverlay's mount-effect calls this; stub returns OK so the
+          // catch path doesn't surface in unrelated specs.
+          return null;
+        }
         if (cmd === "plugin:event|listen") {
           const { event, handler } = (args ?? {}) as {
             event: string;

--- a/apps/tauri/tests/settings-window.spec.ts
+++ b/apps/tauri/tests/settings-window.spec.ts
@@ -119,6 +119,62 @@ test.describe("settings view", () => {
     await expect(sw).toBeChecked();
   });
 
+  // Manual multi-monitor smoke (NOT covered here — these tests cover the
+  // toggle UI half only):
+  // 1. With Follow active screen ON, focus an app on display 1, then on
+  //    display 2 — pill should jump bottom-center of display 2 within
+  //    ~500 ms.
+  // 2. Mid-recording switch: start recording on display 1, focus an app
+  //    on display 2 — pill follows; level meter and SVG tween continue
+  //    without flicker.
+  // 3. With the toggle OFF, the pill stays on whichever monitor it last
+  //    landed on through arbitrary focus changes.
+
+  test("Follow active screen Switch defaults to ON", async ({ page }) => {
+    await page.goto("/");
+    await openSettings(page);
+    await expect(
+      page.getByRole("switch", { name: "Follow active screen" }),
+    ).toBeChecked();
+  });
+
+  test("flipping Follow active screen invokes settings_set_pill_follow with false", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await openSettings(page);
+    const sw = page.getByRole("switch", { name: "Follow active screen" });
+    await expect(sw).toBeChecked();
+    await sw.click();
+    await expect(sw).not.toBeChecked();
+    const lastFollow = await page.evaluate(
+      () =>
+        (window as unknown as { __owPillLastFollow?: boolean })
+          .__owPillLastFollow,
+    );
+    expect(lastFollow).toBe(false);
+    const setCount = await page.evaluate(
+      () =>
+        (window as unknown as { __owPillSetCount?: number }).__owPillSetCount ??
+        0,
+    );
+    expect(setCount).toBe(1);
+  });
+
+  test("Follow active screen hydrates from stored OFF value", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      (window as unknown as { __owPillFollow?: boolean }).__owPillFollow =
+        false;
+    });
+    await page.goto("/");
+    await openSettings(page);
+    await expect(
+      page.getByRole("switch", { name: "Follow active screen" }),
+    ).not.toBeChecked();
+  });
+
   test("Theme picker flips the dark/light class on <html>", async ({
     page,
   }) => {

--- a/backlog/tasks/task-55.1 - Plan-Task-1-Settings-schema-atomic-flag-and-commands.md
+++ b/backlog/tasks/task-55.1 - Plan-Task-1-Settings-schema-atomic-flag-and-commands.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-55.1
 title: 'Plan Task 1: Settings schema, atomic flag, and commands'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 08:01'
+updated_date: '2026-04-29 18:50'
 labels:
   - 55-impl
 dependencies: []
@@ -18,9 +20,21 @@ Add pill.follow_active_screen block to settings.json, expose a process-global At
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PillSettings type added with follow_active_screen: bool, default true
-- [ ] #2 follow_active_screen() returns true on a fresh checkout and on a settings file without the pill block
-- [ ] #3 settings_set_pill_follow(false) persists the JSON field AND flips the in-memory atomic in the same call
-- [ ] #4 Both Tauri commands registered in invoke_handler!
-- [ ] #5 cargo check clean, no new warnings
+- [x] #1 PillSettings type added with follow_active_screen: bool, default true
+- [x] #2 follow_active_screen() returns true on a fresh checkout and on a settings file without the pill block
+- [x] #3 settings_set_pill_follow(false) persists the JSON field AND flips the in-memory atomic in the same call
+- [x] #4 Both Tauri commands registered in invoke_handler!
+- [x] #5 cargo check clean, no new warnings
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+ee05695 Settings: PillSettings + FOLLOW_ACTIVE_SCREEN atomic + 2 commands; cargo check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added PillSettings (default ON), FOLLOW_ACTIVE_SCREEN AtomicBool, settings_get_pill + settings_set_pill_follow commands. load_settings hydrates the atomic on first call; setter writes JSON + flips atomic atomically. Sibling save fns updated to preserve pill block. cargo check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-55.2 - Plan-Task-2-focused_window_monitor-on-macOS.md
+++ b/backlog/tasks/task-55.2 - Plan-Task-2-focused_window_monitor-on-macOS.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-55.2
 title: 'Plan Task 2: focused_window_monitor() on macOS'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 08:01'
+updated_date: '2026-04-29 18:54'
 labels:
   - 55-impl
 dependencies: []
@@ -18,9 +20,21 @@ Extend the AX walk in fullscreen/mac.rs to return the origin of the monitor cont
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 pub fn focused_window_monitor() -> Option<(i32, i32)> exists in fullscreen/mac.rs
-- [ ] #2 Returns None when AXFocusedApplication, AXFocusedWindow, position, or size queries fail
-- [ ] #3 Returns Some(origin) matching the focused window's display when AX is granted and a window has focus
-- [ ] #4 is_fullscreen_now() behavior unchanged
-- [ ] #5 cargo check clean on aarch64-apple-darwin
+- [x] #1 pub fn focused_window_monitor() -> Option<(i32, i32)> exists in fullscreen/mac.rs
+- [x] #2 Returns None when AXFocusedApplication, AXFocusedWindow, position, or size queries fail
+- [x] #3 Returns Some(origin) matching the focused window's display when AX is granted and a window has focus
+- [x] #4 is_fullscreen_now() behavior unchanged
+- [x] #5 cargo check clean on aarch64-apple-darwin
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+11365f0 Fullscreen mac: focused_window_monitor() — AX walk + CG display lookup; cargo check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added focused_window_monitor() to fullscreen/mac.rs: extends the existing AX walk with kAXPositionAttribute + kAXSizeAttribute (unpacked via AXValueGetValue), then walks CGDisplay::active_displays() and returns the origin tuple of the display containing the window centre. Returns None on any failure. is_fullscreen_now unchanged. cargo check clean on aarch64-apple-darwin.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-55.3 - Plan-Task-3-focused_window_monitor-on-Windows.md
+++ b/backlog/tasks/task-55.3 - Plan-Task-3-focused_window_monitor-on-Windows.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-55.3
 title: 'Plan Task 3: focused_window_monitor() on Windows'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 08:01'
+updated_date: '2026-04-29 18:55'
 labels:
   - 55-impl
 dependencies: []
@@ -18,9 +20,21 @@ Add focused_window_monitor to fullscreen/windows.rs by extracting the foreground
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Private helper foreground_monitor_info() extracted; both is_fullscreen_now and focused_window_monitor use it
-- [ ] #2 is_fullscreen_now() returns the same value as before for the same inputs
-- [ ] #3 focused_window_monitor() returns Some((rcMonitor.left, rcMonitor.top)) for the focused window
-- [ ] #4 All four shell-window classes still filtered (Progman, WorkerW, Shell_TrayWnd, Shell_SecondaryTrayWnd)
-- [ ] #5 cargo check clean on x86_64-pc-windows-msvc
+- [x] #1 Private helper foreground_monitor_info() extracted; both is_fullscreen_now and focused_window_monitor use it
+- [x] #2 is_fullscreen_now() returns the same value as before for the same inputs
+- [x] #3 focused_window_monitor() returns Some((rcMonitor.left, rcMonitor.top)) for the focused window
+- [x] #4 All four shell-window classes still filtered (Progman, WorkerW, Shell_TrayWnd, Shell_SecondaryTrayWnd)
+- [x] #5 cargo check clean on x86_64-pc-windows-msvc
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+fabb6e9 Fullscreen win: foreground_monitor_info helper + focused_window_monitor; cargo check clean on both targets.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Extracted foreground_monitor_info() returning (HWND, RECT, MONITORINFO) — both is_fullscreen_now and focused_window_monitor route through it. Deviated from plan signature by including HWND so the chromeless branch reads style bits from the same window as the rect (avoids a second GetForegroundWindow race). is_fullscreen_now behavior preserved; all four shell classes still filtered. focused_window_monitor returns Some((rcMonitor.left, rcMonitor.top)). cargo check clean on x86_64-pc-windows-gnu (and aarch64-apple-darwin).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-55.4 - Plan-Task-4-Watcher-emits-monitor-changed-signal.md
+++ b/backlog/tasks/task-55.4 - Plan-Task-4-Watcher-emits-monitor-changed-signal.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-55.4
 title: 'Plan Task 4: Watcher emits monitor-changed signal'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 08:01'
+updated_date: '2026-04-29 18:57'
 labels:
   - 55-impl
 dependencies: []
@@ -18,9 +20,21 @@ Extend fullscreen/mod.rs so a single 500 ms poll thread serves both the fullscre
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One poll thread regardless of which install_* function(s) the caller invokes
-- [ ] #2 install_pill_follow callback fires on monitor-origin change with Some(origin)
-- [ ] #3 Callback does NOT fire when focused_window_monitor() returns None
-- [ ] #4 Callback does NOT fire when settings::follow_active_screen() is false
-- [ ] #5 Existing fullscreen callback behavior unchanged
+- [x] #1 One poll thread regardless of which install_* function(s) the caller invokes
+- [x] #2 install_pill_follow callback fires on monitor-origin change with Some(origin)
+- [x] #3 Callback does NOT fire when focused_window_monitor() returns None
+- [x] #4 Callback does NOT fire when settings::follow_active_screen() is false
+- [x] #5 Existing fullscreen callback behavior unchanged
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+828e1ce Pill-follow watcher: install_pill_follow + LAST_MONITOR + gated poll tick; cargo check clean on both targets.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Refactored install→install_fullscreen with pub-use alias, added install_pill_follow, single ensure_poller_started gates the spawn. Poll tick checks settings::follow_active_screen() then queries cfg-dispatched focused_window_monitor(); fires MONITOR_CB only on tuple change. LAST_MONITOR not reset on gate-off so re-arming doesn't replay. cargo check clean on both targets.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-55.5 - Plan-Task-5-Reposition-pill-on-monitor-change-boot-wiring.md
+++ b/backlog/tasks/task-55.5 - Plan-Task-5-Reposition-pill-on-monitor-change-boot-wiring.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-55.5
 title: 'Plan Task 5: Reposition pill on monitor change + boot wiring'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-04-29 08:01'
+updated_date: '2026-04-29 19:02'
 labels:
   - 55-impl
 dependencies: []
@@ -21,6 +23,19 @@ Rename position_pill_bottom_center to reposition_pill, accept an optional monito
 - [ ] #1 Pill repositions to bottom-center of new monitor within ~500 ms of foreground switch (multi-monitor smoke)
 - [ ] #2 Recording-in-progress pill follows without disrupting the SVG tween or level meter
 - [ ] #3 Single-monitor: zero set_position calls beyond the boot placement
-- [ ] #4 reposition_pill registered in invoke_handler!; PillOverlay.tsx invoke updated
-- [ ] #5 Old position_pill_bottom_center symbol removed
+- [x] #4 reposition_pill registered in invoke_handler!; PillOverlay.tsx invoke updated
+- [x] #5 Old position_pill_bottom_center symbol removed
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+1a12758 reposition_pill + place_pill helper + find_tauri_monitor (mac/win) + watcher callback in setup + alias removed + PillOverlay invoke renamed.
+ACs #1-3 require multi-monitor mac smoke (deferred to manual verification per plan).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+reposition_pill takes optional monitor_origin; on Some dispatches to fullscreen::find_tauri_monitor (cfg-routed). mac side converts Tauri monitor position from physical-px to logical points; win compares direct. place_pill helper called from both the command and the watcher callback, both wrapped in app.run_on_main_thread. install→install_fullscreen alias removed; pill-follow callback registered alongside. Frontend invoke renamed and passes { monitor_origin: null }. cargo check clean both targets, tsc clean. ACs #1-3 require multi-monitor mac smoke (handover-flagged manual step).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-55.6 - Plan-Task-6-Settings-UI-toggle-in-General-pane.md
+++ b/backlog/tasks/task-55.6 - Plan-Task-6-Settings-UI-toggle-in-General-pane.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-55.6
 title: 'Plan Task 6: Settings UI toggle in General pane'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 08:01'
-updated_date: '2026-04-29 08:27'
+updated_date: '2026-04-29 19:04'
 labels:
   - 55-impl
 dependencies:
@@ -20,8 +21,20 @@ Surface 'Follow active screen' in Settings → General, default ON, persisting v
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 General pane renders the toggle and reflects persisted state on open
-- [ ] #2 Flipping the toggle updates settings.json AND the in-process atomic on the same interaction (no restart needed)
-- [ ] #3 New users see toggle in the ON position by default
-- [ ] #4 Uses shadcn Switch + Field primitives consistent with the rest of GeneralPane (TASK-56)
+- [x] #1 General pane renders the toggle and reflects persisted state on open
+- [x] #2 Flipping the toggle updates settings.json AND the in-process atomic on the same interaction (no restart needed)
+- [x] #3 New users see toggle in the ON position by default
+- [x] #4 Uses shadcn Switch + Field primitives consistent with the rest of GeneralPane (TASK-56)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+8694f8b General pane Pill section: Switch + invoke wiring + optimistic update with revert.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Pill section in GeneralPane between Appearance and Updates. Switch hydrated from settings_get_pill (defaults ON on rejection, matching Rust-side default). Toggle flip = optimistic UI update + invoke settings_set_pill_follow, with state revert + console.warn on rejection. Uses the same Field/Switch primitives as launch-at-login. tsc clean.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-55.7 - Plan-Task-7-Playwright-spec-for-the-toggle.md
+++ b/backlog/tasks/task-55.7 - Plan-Task-7-Playwright-spec-for-the-toggle.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-55.7
 title: 'Plan Task 7: Playwright spec for the toggle'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-04-29 08:01'
+updated_date: '2026-04-29 19:05'
 labels:
   - 55-impl
 dependencies: []
@@ -18,9 +20,21 @@ Cover the UI half with Playwright. Multi-monitor follow behavior itself is not C
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Playwright assertion: toggle is ON by default
-- [ ] #2 Playwright assertion: flipping calls settings_set_pill_follow with { follow: false }
-- [ ] #3 Playwright assertion: toggle hydrates OFF when settings_get_pill returns follow_active_screen: false
+- [x] #1 Playwright assertion: toggle is ON by default
+- [x] #2 Playwright assertion: flipping calls settings_set_pill_follow with { follow: false }
+- [x] #3 Playwright assertion: toggle hydrates OFF when settings_get_pill returns follow_active_screen: false
 - [ ] #4 Manual multi-monitor smoke steps documented in spec file or sibling MANUAL.md
 - [ ] #5 pnpm test:ui runs green locally and on CI
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+d10b424 Playwright: 3 specs (default-ON, set-on-flip, hydrate-OFF) + shim handlers; 43/43 green.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added three Playwright tests in settings-window.spec.ts covering default-ON, set-on-flip (asserts settings_set_pill_follow invoked with { follow: false } via __owPillLastFollow / __owPillSetCount probes), and hydrate-OFF (addInitScript stashes __owPillFollow=false before goto). Tauri-shim got settings_get_pill / settings_set_pill_follow / reposition_pill (noop) handlers. Manual multi-monitor smoke steps documented as a // Manual: comment block above the new tests. pnpm test:ui passes 43/43.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/docs/superpowers/specs/2026-04-29-pill-follows-active-screen.md
+++ b/docs/superpowers/specs/2026-04-29-pill-follows-active-screen.md
@@ -80,3 +80,33 @@ The pill should sit on whichever monitor hosts the currently-focused application
 - Existing watcher backbone: `apps/tauri/src-tauri/src/fullscreen/mod.rs`, `…/mac.rs`, `…/windows.rs`.
 - Current static-position command: `position_pill_bottom_center` in `apps/tauri/src-tauri/src/lib.rs:326`.
 - Project principles applied: zero-config-over-toggles (lead with auto-on), orchestration-in-rust (position decision lives in Rust shell, UI is dumb).
+
+---
+
+## Decision update — 2026-04-30: cursor-tracking, not focused-window
+
+The original implementation tracked the **focused window's centre** via the AX path (`AXFocusedApplication → AXFocusedWindow → kAXPositionAttribute + kAXSizeAttribute`). Manual smoke on a multi-monitor Mac surfaced two problems:
+
+1. **Electron apps silently dropped.** Figma, Discord, and VS Code don't reliably expose `kAXPositionAttribute` / `kAXSizeAttribute`, so the watcher returned `None` and the pill stayed put. Cocoa apps next to them on the same monitor triggered the follow correctly, which made the asymmetry obvious.
+2. **`set_position` on the swizzled NSPanel wedged Finder's app menu.** Rapid screen-switching with Finder briefly active left the Finder application menu painted on screen, undismissable. Toggling the setting OFF reproducibly stopped the wedge — confirming `set_position` is the trigger. The fix is to fire `set_position` less often, only on actual screen-crossings the user cares about.
+
+Switching to **cursor-monitor tracking** addresses both:
+
+- Cursor position is reported uniformly across Cocoa, Electron, Win32, UWP, and fullscreen contexts. No AX dependency for the pill-follow signal (AX is still used for fullscreen detection).
+- Users typically focus an app *by clicking it*, so cursor-on-target is a high-confidence proxy for "where the user is working." Matches Wispr Flow's pattern.
+- Cursor crossings are rarer than focus changes, which reduces `set_position` call frequency and makes the Finder-menu wedge harder to reproduce.
+
+### Implementation deltas vs the original spec
+
+| Original | Updated |
+|---|---|
+| `mac::focused_window_monitor()` walks AX → CG bounds | `mac::cursor_monitor()` reads `CGEventCreate(null)` + `CGEventGetLocation`, walks `CGDisplay::active_displays()` |
+| `windows::focused_window_monitor()` reuses `foreground_monitor_info()` | `windows::cursor_monitor()` uses `GetCursorPos()` + `MonitorFromPoint(MONITOR_DEFAULTTONEAREST)` |
+| Skip cases include AX-revoked, no focused window, shell classes | Skip cases reduce to "CG / Win API failure" — the others don't apply |
+| Spec said "the monitor whose rect contains the centre of the focused window" | Now: "the monitor whose rect contains the cursor" |
+
+The watcher backbone (`LAST_MONITOR` cache, gating on `settings::follow_active_screen()`, 500 ms poll) is unchanged. `find_tauri_monitor` is unchanged — coordinate-space contract is identical (cursor coords match the existing watcher tuple format on each platform).
+
+### What stayed in the AX module
+
+`is_fullscreen_now()` still uses the original AX walk (`AXFocusedApplication → AXFocusedWindow → kAXFullScreenAttribute`). That signal is unrelated to where the cursor is and works fine across all app frameworks for native NSWindow fullscreen detection.


### PR DESCRIPTION
## Summary

- Pill follows the cursor's active screen (poll-based watcher, gated on a new General-pane "Follow active screen" toggle).
- Dock-/taskbar-aware bottom anchor with a wider gap on screens that have no Dock/taskbar so the pill doesn't sit at the seam between stacked monitors.
- Main window centers on the screen the user just clicked the pill from.
- Cross-DPI position fix: `set_position` is now routed through a per-platform helper (`LogicalPosition` on macOS, `PhysicalPosition` pre-multiplied by the destination scale on Windows) — fixes pill ending up mid-screen on Win and main window oversized + off-screen on the ultrawide secondary.

## Test plan

- [x] Mac: pill follows cursor across stacked-vertical multi-monitor (primary @2x + secondary @1x). Anchors above Dock when present, 80pt above bare bottom edge otherwise.
- [x] Mac: main window centers on the pill's monitor on click.
- [x] Win: pill anchors 24pt above taskbar.
- [x] Win: main window centers on the followed screen for both primary and ultrawide secondary.
- [x] Playwright: 47/47 pass (`pnpm exec playwright test`).