### PR TITLE
task-60: wire launch-at-login backend (autostart plugin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +866,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -869,6 +889,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1003,7 +1034,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2824,6 +2855,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-nspanel",
+ "tauri-plugin-autostart",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "windows 0.61.3",
@@ -4511,6 +4543,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6059,6 +6105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -36,6 +36,7 @@
     "@fontsource-variable/geist": "5.2.8",
     "@radix-ui/react-slot": "1.2.4",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-autostart": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/apps/tauri/pnpm-lock.yaml
+++ b/apps/tauri/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-autostart':
+        specifier: ^2
+        version: 2.5.1
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
@@ -1576,6 +1579,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
@@ -4442,6 +4448,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -22,6 +22,12 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
+# Cross-platform launch-at-login. Windows: HKCU\Software\Microsoft\Windows\
+# CurrentVersion\Run; macOS: ~/Library/LaunchAgents/<productName>.plist via
+# the auto-launch crate's LaunchAgent path (NOT the Service Management
+# framework's SMAppService — LSUIElement / menu-bar apps need a plain
+# LaunchAgent, see lib.rs registration site for the full rationale).
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 openwhisper-core = { path = "../../../core", default-features = false, features = ["tauri"] }

--- a/apps/tauri/src-tauri/capabilities/default.json
+++ b/apps/tauri/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "core:window:allow-primary-monitor",
     "core:window:allow-available-monitors",
     "core:window:allow-start-dragging",
-    "opener:default"
+    "opener:default",
+    "autostart:default"
   ]
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -710,7 +710,40 @@ pub fn run() {
                 let _ = w.set_focus();
             }
         }))
-        .plugin(tauri_plugin_opener::init());
+        .plugin(tauri_plugin_opener::init())
+        // Launch at login. Cross-platform autostart registration with no
+        // platform-specific code on our side — the plugin handles the
+        // divergence:
+        //   - Windows: writes the user-scope Run key
+        //     `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`. Inspect
+        //     with `reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run`.
+        //   - macOS: writes a LaunchAgent plist at
+        //     `~/Library/LaunchAgents/<productName>.plist`. Inspect with
+        //     `ls ~/Library/LaunchAgents/`.
+        // We deliberately pin macos_launcher to LaunchAgent (also the
+        // plugin default) rather than AppleScript or SMAppService.
+        // OpenWhisper sets activation policy = Accessory (menu-bar-only,
+        // LSUIElement-equivalent at runtime) and SMAppService's
+        // login-items API is geared at normal Dock-icon apps — using it
+        // here would either fail silently or surface a system-managed
+        // login-items entry the user doesn't expect.
+        // Bundle identifier `com.openwhisper.app` (note the `.app`
+        // suffix Tauri logs a warning about at build time): if anyone
+        // ever changes the productName in tauri.conf.json the
+        // LaunchAgent plist filename changes with it and existing
+        // autostart entries silently break for upgraders.
+        // app_name is left at its default (`package_info().name`, which
+        // resolves to productName) so the dev overlay registers as
+        // "OpenWhisper Dev" and the release registers as "OpenWhisper" —
+        // dev runs don't fight release autostart entries.
+        .plugin({
+            let mut b = tauri_plugin_autostart::Builder::new();
+            #[cfg(target_os = "macos")]
+            {
+                b = b.macos_launcher(tauri_plugin_autostart::MacosLauncher::LaunchAgent);
+            }
+            b.build()
+        });
 
     #[cfg(target_os = "macos")]
     let builder = builder.plugin(tauri_nspanel::init());

--- a/apps/tauri/src/components/general-pane.tsx
+++ b/apps/tauri/src/components/general-pane.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import {
+  disable as autostartDisable,
+  enable as autostartEnable,
+  isEnabled as autostartIsEnabled,
+} from "@tauri-apps/plugin-autostart";
 
 import { Switch } from "@/components/ui/switch";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -17,7 +22,12 @@ import { useTheme } from "@/lib/use-theme";
 type PillSettings = { follow_active_screen: boolean };
 
 export function GeneralPane() {
-  const [launchAtLogin, setLaunchAtLogin] = useState(true);
+  // Hydrated from the platform autostart registration on mount, NOT from
+  // local state — a user who enabled autostart in a previous run sees the
+  // Switch reflect reality after a fresh boot. False is the safe default
+  // before isEnabled() resolves: we'd rather render a momentary unchecked
+  // Switch and flip it on than render checked and silently flip it off.
+  const [launchAtLogin, setLaunchAtLogin] = useState(false);
   const { theme, setTheme } = useTheme();
   const { enabled: showInFullscreen, setEnabled: setShowInFullscreen } =
     useShowInFullscreen();
@@ -31,10 +41,30 @@ export function GeneralPane() {
   }, []);
 
   useEffect(() => {
+    autostartIsEnabled()
+      .then(setLaunchAtLogin)
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.warn("autostart isEnabled failed", e);
+        setLaunchAtLogin(false);
+      });
+  }, []);
+
+  useEffect(() => {
     invoke<PillSettings>("settings_get_pill")
       .then((s) => setFollowActiveScreen(s.follow_active_screen))
       .catch(() => setFollowActiveScreen(true));
   }, []);
+
+  const onLaunchAtLoginChange = (next: boolean) => {
+    setLaunchAtLogin(next);
+    const apply = next ? autostartEnable() : autostartDisable();
+    apply.catch((e) => {
+      // eslint-disable-next-line no-console
+      console.warn(`autostart ${next ? "enable" : "disable"} failed`, e);
+      setLaunchAtLogin(!next);
+    });
+  };
 
   const onFollowChange = (next: boolean) => {
     setFollowActiveScreen(next);
@@ -58,7 +88,7 @@ export function GeneralPane() {
         <Switch
           id="launch-at-login"
           checked={launchAtLogin}
-          onCheckedChange={setLaunchAtLogin}
+          onCheckedChange={onLaunchAtLoginChange}
         />
       </Field>
 

--- a/apps/tauri/tests/fixtures/tauri-shim.ts
+++ b/apps/tauri/tests/fixtures/tauri-shim.ts
@@ -202,6 +202,46 @@ async function installTauriShim(page: Page, label: "main" = "main") {
           w.__owAudioPreviewStops = (w.__owAudioPreviewStops ?? 0) + 1;
           return null;
         }
+        if (cmd === "plugin:autostart|is_enabled") {
+          const w = window as unknown as {
+            __owAutostart?: boolean;
+            __owAutostartIsEnabledShouldThrow?: boolean;
+          };
+          if (w.__owAutostartIsEnabledShouldThrow) {
+            throw new Error("autostart isEnabled failed");
+          }
+          return w.__owAutostart ?? false;
+        }
+        if (cmd === "plugin:autostart|enable") {
+          const w = window as unknown as {
+            __owAutostart?: boolean;
+            __owAutostartEnableShouldThrow?: boolean;
+            __owAutostartEnableCount?: number;
+            __owAutostartLastSet?: boolean;
+          };
+          w.__owAutostartEnableCount = (w.__owAutostartEnableCount ?? 0) + 1;
+          if (w.__owAutostartEnableShouldThrow) {
+            throw new Error("autostart enable failed");
+          }
+          w.__owAutostart = true;
+          w.__owAutostartLastSet = true;
+          return null;
+        }
+        if (cmd === "plugin:autostart|disable") {
+          const w = window as unknown as {
+            __owAutostart?: boolean;
+            __owAutostartDisableShouldThrow?: boolean;
+            __owAutostartDisableCount?: number;
+            __owAutostartLastSet?: boolean;
+          };
+          w.__owAutostartDisableCount = (w.__owAutostartDisableCount ?? 0) + 1;
+          if (w.__owAutostartDisableShouldThrow) {
+            throw new Error("autostart disable failed");
+          }
+          w.__owAutostart = false;
+          w.__owAutostartLastSet = false;
+          return null;
+        }
         if (cmd === "settings_get_pill") {
           const stored = (window as unknown as { __owPillFollow?: boolean })
             .__owPillFollow;

--- a/apps/tauri/tests/settings-window.spec.ts
+++ b/apps/tauri/tests/settings-window.spec.ts
@@ -67,12 +67,100 @@ test.describe("settings view", () => {
     ).toHaveAttribute("aria-pressed", "false");
   });
 
-  test("Launch at login Switch starts checked", async ({ page }) => {
+  test("Launch at login Switch starts unchecked when not registered", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await openSettings(page);
+    await expect(
+      page.getByRole("switch", { name: "Launch at login" }),
+    ).not.toBeChecked();
+  });
+
+  test("Launch at login Switch hydrates from autostart isEnabled", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      (window as unknown as { __owAutostart?: boolean }).__owAutostart = true;
+    });
     await page.goto("/");
     await openSettings(page);
     await expect(
       page.getByRole("switch", { name: "Launch at login" }),
     ).toBeChecked();
+  });
+
+  test("Toggling Launch at login on invokes autostart enable", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await openSettings(page);
+    const sw = page.getByRole("switch", { name: "Launch at login" });
+    await expect(sw).not.toBeChecked();
+    await sw.click();
+    await expect(sw).toBeChecked();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __owAutostartLastSet?: boolean })
+              .__owAutostartLastSet,
+        ),
+      )
+      .toBe(true);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __owAutostartEnableCount?: number })
+            .__owAutostartEnableCount ?? 0,
+      ),
+    ).toBe(1);
+  });
+
+  test("Toggling Launch at login off invokes autostart disable", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      (window as unknown as { __owAutostart?: boolean }).__owAutostart = true;
+    });
+    await page.goto("/");
+    await openSettings(page);
+    const sw = page.getByRole("switch", { name: "Launch at login" });
+    await expect(sw).toBeChecked();
+    await sw.click();
+    await expect(sw).not.toBeChecked();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __owAutostartLastSet?: boolean })
+              .__owAutostartLastSet,
+        ),
+      )
+      .toBe(false);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __owAutostartDisableCount?: number })
+            .__owAutostartDisableCount ?? 0,
+      ),
+    ).toBe(1);
+  });
+
+  test("Failed autostart enable reverts the Switch", async ({ page }) => {
+    await page.addInitScript(() => {
+      (
+        window as unknown as { __owAutostartEnableShouldThrow?: boolean }
+      ).__owAutostartEnableShouldThrow = true;
+    });
+    await page.goto("/");
+    await openSettings(page);
+    const sw = page.getByRole("switch", { name: "Launch at login" });
+    await expect(sw).not.toBeChecked();
+    await sw.click();
+    // The optimistic flip lands first; the rejected promise then reverts
+    // the state back to unchecked.
+    await expect(sw).not.toBeChecked();
   });
 
   test("Show in fullscreen Switch reflects behavior_get on mount", async ({

--- a/backlog/tasks/task-60 - Wire-Launch-at-login-backend-Windows-Mac-—-autostart-plugin.md
+++ b/backlog/tasks/task-60 - Wire-Launch-at-login-backend-Windows-Mac-—-autostart-plugin.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-60
-title: 'Wire Launch-at-login backend (Windows + Mac) — autostart plugin'
-status: To Do
+title: Wire Launch-at-login backend (Windows + Mac) — autostart plugin
+status: In Progress
 assignee: []
 created_date: '2026-04-30 09:35'
+updated_date: '2026-05-01 13:14'
 labels:
   - windows
   - macos
@@ -26,14 +27,13 @@ Cross-platform parity is part of the AC: even though the regression was only con
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 Add `tauri-plugin-autostart` (or equivalent) to `apps/tauri/src-tauri/Cargo.toml` and register it in the Tauri builder in `apps/tauri/src-tauri/src/main.rs` (or wherever plugins are registered).
-- [ ] #2 The Switch in `apps/tauri/src/settings/General/Startup.tsx` (or wherever the existing UI stub lives) calls a Tauri command that enables/disables autostart on flip. Toggling the Switch off removes the autostart entry; toggling it on creates the entry.
-- [ ] #3 The Switch state is read from the actual platform autostart registration on mount, not just from local React state — so a user who enabled autostart in a previous run sees the Switch reflect reality after a restart.
+- [x] #1 Add `tauri-plugin-autostart` (or equivalent) to `apps/tauri/src-tauri/Cargo.toml` and register it in the Tauri builder in `apps/tauri/src-tauri/src/main.rs` (or wherever plugins are registered).
+- [x] #2 The Switch in `apps/tauri/src/settings/General/Startup.tsx` (or wherever the existing UI stub lives) calls a Tauri command that enables/disables autostart on flip. Toggling the Switch off removes the autostart entry; toggling it on creates the entry.
+- [x] #3 The Switch state is read from the actual platform autostart registration on mount, not just from local React state — so a user who enabled autostart in a previous run sees the Switch reflect reality after a restart.
 - [ ] #4 Manual smoke on Windows 11: enable Switch → close OpenWhisper → sign out of Windows → sign back in → OpenWhisper launches automatically (tray icon visible). Then disable Switch → sign out → sign back in → OpenWhisper does NOT launch.
 - [ ] #5 Manual smoke on macOS (Sequoia 15+, arm64): enable Switch → quit OpenWhisper → log out → log in → OpenWhisper launches and the menu-bar mic icon appears (no Dock icon, since LSUIElement = true). Then disable Switch → log out → log in → OpenWhisper does NOT launch.
-- [ ] #6 Behaviour with the autostart plugin is documented in a code-comment at the registration site (or a short module doc-comment) covering: which platform-level mechanism is used on each OS, the bundle-identifier the registration is keyed on, and how to manually inspect the registration (Windows: `reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run`; macOS: `ls ~/Library/LaunchAgents/`).
+- [x] #6 Behaviour with the autostart plugin is documented in a code-comment at the registration site (or a short module doc-comment) covering: which platform-level mechanism is used on each OS, the bundle-identifier the registration is keyed on, and how to manually inspect the registration (Windows: `reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run`; macOS: `ls ~/Library/LaunchAgents/`).
 - [ ] #7 v0.4.1 release notes mention "Launch-at-login Switch is now functional on both Windows and macOS" and the v0.4.1 release ships with both platforms verified.
 <!-- AC:END -->
 

--- a/backlog/tasks/task-60 - Wire-Launch-at-login-backend-Windows-Mac-—-autostart-plugin.md
+++ b/backlog/tasks/task-60 - Wire-Launch-at-login-backend-Windows-Mac-—-autostart-plugin.md
@@ -4,7 +4,7 @@ title: Wire Launch-at-login backend (Windows + Mac) — autostart plugin
 status: In Progress
 assignee: []
 created_date: '2026-04-30 09:35'
-updated_date: '2026-05-01 13:14'
+updated_date: '2026-05-01 13:15'
 labels:
   - windows
   - macos
@@ -47,4 +47,6 @@ Background pointers:
 - Watch out for the macOS bundle-identifier conflict noted in `tauri.conf.json` (`com.openwhisper.app` ends with `.app` — the warning Tauri logs at build time). LaunchAgent plists key off the bundle ID; if anyone changes it later, autostart entries will silently break for users who upgrade.
 - Do NOT roll a custom registry-write / plist-write — `tauri-plugin-autostart` already handles the cross-platform differences (Windows HKCU Run key vs LaunchAgent plist vs macOS Service Management framework on newer OS versions). Custom code here would re-invent the bugs the plugin already solved.
 - LSUIElement = true on Mac means OpenWhisper has no Dock icon. Some autostart plumbing assumes a Dock-icon app; verify the plugin's macOS path uses a LaunchAgent plist (works for menu-bar apps) and not the Service Management framework's "login item" API (which expects a normal app and may fail silently or show a system-managed login-items entry the user doesn't expect).
+
+Implementation commit: dbdd2a7 (branch task-60-launch-at-login). tauri-plugin-autostart 2.5.1 wired in apps/tauri/src-tauri (MacosLauncher::LaunchAgent on macOS). General pane Switch reads via @tauri-apps/plugin-autostart isEnabled() on mount; enable()/disable() on flip with revert-on-rejection. Capability autostart:default added. Playwright tests/settings-window.spec.ts covers hydration + invoke + revert; existing 51-test suite green locally. ACs 1/2/3/6 covered by code + tests; ACs 4/5/7 left for the user — manual sign-out cycle on Win11 + macOS Sequoia and v0.4.1 release-notes line.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-60 - Wire-Launch-at-login-backend-Windows-Mac-—-autostart-plugin.md
+++ b/backlog/tasks/task-60 - Wire-Launch-at-login-backend-Windows-Mac-—-autostart-plugin.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-60
 title: Wire Launch-at-login backend (Windows + Mac) — autostart plugin
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-30 09:35'
-updated_date: '2026-05-01 13:15'
+updated_date: '2026-05-01 16:23'
 labels:
   - windows
   - macos
@@ -31,8 +31,8 @@ Cross-platform parity is part of the AC: even though the regression was only con
 - [x] #1 Add `tauri-plugin-autostart` (or equivalent) to `apps/tauri/src-tauri/Cargo.toml` and register it in the Tauri builder in `apps/tauri/src-tauri/src/main.rs` (or wherever plugins are registered).
 - [x] #2 The Switch in `apps/tauri/src/settings/General/Startup.tsx` (or wherever the existing UI stub lives) calls a Tauri command that enables/disables autostart on flip. Toggling the Switch off removes the autostart entry; toggling it on creates the entry.
 - [x] #3 The Switch state is read from the actual platform autostart registration on mount, not just from local React state — so a user who enabled autostart in a previous run sees the Switch reflect reality after a restart.
-- [ ] #4 Manual smoke on Windows 11: enable Switch → close OpenWhisper → sign out of Windows → sign back in → OpenWhisper launches automatically (tray icon visible). Then disable Switch → sign out → sign back in → OpenWhisper does NOT launch.
-- [ ] #5 Manual smoke on macOS (Sequoia 15+, arm64): enable Switch → quit OpenWhisper → log out → log in → OpenWhisper launches and the menu-bar mic icon appears (no Dock icon, since LSUIElement = true). Then disable Switch → log out → log in → OpenWhisper does NOT launch.
+- [x] #4 Manual smoke on Windows 11: enable Switch → close OpenWhisper → sign out of Windows → sign back in → OpenWhisper launches automatically (tray icon visible). Then disable Switch → sign out → sign back in → OpenWhisper does NOT launch.
+- [x] #5 Manual smoke on macOS (Sequoia 15+, arm64): enable Switch → quit OpenWhisper → log out → log in → OpenWhisper launches and the menu-bar mic icon appears (no Dock icon, since LSUIElement = true). Then disable Switch → log out → log in → OpenWhisper does NOT launch.
 - [x] #6 Behaviour with the autostart plugin is documented in a code-comment at the registration site (or a short module doc-comment) covering: which platform-level mechanism is used on each OS, the bundle-identifier the registration is keyed on, and how to manually inspect the registration (Windows: `reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run`; macOS: `ls ~/Library/LaunchAgents/`).
 - [ ] #7 v0.4.1 release notes mention "Launch-at-login Switch is now functional on both Windows and macOS" and the v0.4.1 release ships with both platforms verified.
 <!-- AC:END -->
@@ -49,4 +49,6 @@ Background pointers:
 - LSUIElement = true on Mac means OpenWhisper has no Dock icon. Some autostart plumbing assumes a Dock-icon app; verify the plugin's macOS path uses a LaunchAgent plist (works for menu-bar apps) and not the Service Management framework's "login item" API (which expects a normal app and may fail silently or show a system-managed login-items entry the user doesn't expect).
 
 Implementation commit: dbdd2a7 (branch task-60-launch-at-login). tauri-plugin-autostart 2.5.1 wired in apps/tauri/src-tauri (MacosLauncher::LaunchAgent on macOS). General pane Switch reads via @tauri-apps/plugin-autostart isEnabled() on mount; enable()/disable() on flip with revert-on-rejection. Capability autostart:default added. Playwright tests/settings-window.spec.ts covers hydration + invoke + revert; existing 51-test suite green locally. ACs 1/2/3/6 covered by code + tests; ACs 4/5/7 left for the user — manual sign-out cycle on Win11 + macOS Sequoia and v0.4.1 release-notes line.
+
+Mac smoke (AC #5) green 2026-05-01: enable wrote ~/Library/LaunchAgents/OpenWhisper.plist (Program=/Applications/OpenWhisper.app/Contents/MacOS/openwhisper-tauri, RunAtLoad=true), disable removed it. Sign-out/sign-in cycle relaunched OpenWhisper to menu bar, no Dock icon. AC #4 (Win11) verified by user on Windows box; AC #7 (v0.4.1 release notes) deferred to release time.
 <!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- v0.4.1 hotfix for the Settings → General → Launch at login Switch, which shipped as a UI-only stub in v0.4.0 (confirmed regression on Win11 during 2026-04-30 release smoke: sign-out cycle did not relaunch OpenWhisper).
- Drops in `tauri-plugin-autostart` 2.5.1 with `MacosLauncher::LaunchAgent` so the LSUIElement / menu-bar app gets a plain `~/Library/LaunchAgents/<productName>.plist` rather than an SMAppService entry; Windows uses `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`. Code-comment at the registration site documents the per-platform mechanism + how to inspect it.
- React Switch in `apps/tauri/src/components/general-pane.tsx` now hydrates from `isEnabled()` on mount and calls `enable()` / `disable()` on flip, reverting optimistic state on rejection (same pattern as the existing follow-active-screen toggle).
- Playwright suite extended in `apps/tauri/tests/settings-window.spec.ts` (4 new specs: starts unchecked when not registered, hydrates from stored true, toggling on invokes enable, toggling off invokes disable, failed enable reverts). Full 51-test suite green locally.

Closes [TASK-60](https://github.com/jimmi-joensson/OpenWhisper/blob/task-60-launch-at-login/backlog/tasks/task-60%20-%20Wire-Launch-at-login-backend-Windows-Mac-%E2%80%94-autostart-plugin.md). ACs 1, 2, 3, 6 satisfied by the code + tests below; ACs 4, 5, 7 are manual smoke + release notes and fall to the manual checklist.

## Test plan

### Automated (already green locally)
- [x] `pnpm --filter openwhisper-tauri test:ui` (51 / 51 passing, including 4 new Launch-at-login specs)
- [x] `cargo check -p openwhisper-tauri`
- [x] `pnpm --filter openwhisper-tauri exec tsc --noEmit`

### Manual smoke — Windows 11 (AC #4)
- [ ] Build a release, install, launch OpenWhisper.
- [ ] Open Settings → General → Startup. Toggle **Launch at login** ON.
- [ ] Verify the entry was written: `reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run` should list **OpenWhisper** (or the productName the build was bundled with).
- [ ] Quit OpenWhisper. Sign out of Windows. Sign back in.
- [ ] Expected: OpenWhisper launches automatically (tray icon visible).
- [ ] Toggle **Launch at login** OFF. Confirm the registry entry disappears.
- [ ] Quit, sign out, sign back in. Expected: OpenWhisper does NOT launch.

### Manual smoke — macOS Sequoia 15+ arm64 (AC #5)
- [ ] Build a release, install to `/Applications`, launch OpenWhisper.
- [ ] Open Settings → General → Startup. Toggle **Launch at login** ON.
- [ ] Verify the LaunchAgent plist was written: `ls ~/Library/LaunchAgents/` should show `OpenWhisper.plist`.
- [ ] Quit OpenWhisper. Log out. Log back in.
- [ ] Expected: OpenWhisper launches and the menu-bar mic icon appears (no Dock icon — LSUIElement at runtime via `ActivationPolicy::Accessory`).
- [ ] Toggle **Launch at login** OFF. Confirm the plist disappears.
- [ ] Quit, log out, log back in. Expected: OpenWhisper does NOT launch.

### Notes
- AC #7 (release notes for v0.4.1) is the user's job at release time, not part of this PR.
- Bundle identifier is `com.openwhisper.app`. The plugin keys the LaunchAgent plist filename off `package_info().name` (= productName from `tauri.conf.json`, currently `OpenWhisper`). If anyone ever changes productName the autostart entry will silently break for upgraders — code-comment at the registration site flags this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)