### PR TITLE
Add .github/FUNDING.yml for repo Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+ko_fi: jimmijoensson
+buy_me_a_coffee: jimmijoensson
+custom:
+  - https://paypal.me/jimmijoensson


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` so the GitHub repo renders a "Sponsor" button when public.
- Wires three donation channels: Ko-fi, Buy Me a Coffee, PayPal (via paypal.me).
- Stripe Payment Link slot reserved — will land as a follow-up edit once the link is provisioned.

## Display order
1. `ko_fi: jimmijoensson` — lowest-friction (no account required)
2. `buy_me_a_coffee: jimmijoensson` — broad recognition
3. `paypal.me/jimmijoensson` (in `custom`) — fallback

## Notes
- Repo is still private; the Sponsor button only renders publicly. File is harmless to land now and goes live the moment the repo flips public (TASK-85 rename + go-public).
- Scope-wise this is a slice of TASK-83 (OSS community files) — landing it solo to keep TASK-83 focused on SECURITY.md / CoC / ISSUE_TEMPLATE / CODEOWNERS / dependabot.

## Test plan
- [ ] YAML validates (GitHub will warn in repo settings if not)
- [ ] After repo goes public, confirm "❤ Sponsor" button appears top-right of repo
- [ ] Click-through opens donation chooser with all three options listed in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)